### PR TITLE
Add steps for running tests using local chrome driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,20 @@ to build locally:
 
 bash into the container and run them from there:
 `docker-compose run --entrypoint /bin/bash cla-end-to-end`
+
+## Using your local chrome browser [optional]
+If you want to see the tests running in your hosts machines chrome browser and still have the applications 
+running in their containers then do the following.
+```
+brew install chromedriver
+pip install -r requirements.txt
+chromedriver # take note of the port listed. Will stay running in the foreground
+```
+
+If it does not exist create a `.env` file in the root of the project and add the following
+```
+CLA_E2E_BACKEND_URL=http://localhost:8010
+CLA_E2E_FRONTEND_URL=http://localhost:8011
+CLA_E2E_SELENIUM_WEB_DRIVER_URL=http://localhost:9515
+```
+Finally run the tests in your host running `behave` in your host terminal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,10 @@ services:
     build: .
     volumes:
       - .:/behave_local
+    environment:
+      CLA_E2E_BACKEND_URL: ${CLA_E2E_BACKEND_URL:-http://clabackend:8000}
+      CLA_E2E_FRONTEND_URL: ${CLA_E2E_FRONTEND_URL:-http://clafrontend:8000}
+      CLA_E2E_SELENIUM_WEB_DRIVER_URL: ${CLA_E2E_SELENIUM_WEB_DRIVER_URL:-http://seleniumchrome:4444/wd/hub}
 
   seleniumchrome:
     image: selenium/standalone-chrome:latest

--- a/features/constants.py
+++ b/features/constants.py
@@ -1,3 +1,8 @@
+import os
+CLA_BACKEND_URL = os.environ.get("CLA_E2E_BACKEND_URL")
+CLA_FRONTEND_URL = os.environ.get("CLA_E2E_FRONTEND_URL")
+SELENIUM_WEB_DRIVER_URL = os.environ.get("CLA_E2E_SELENIUM_WEB_DRIVER_URL")
+
 CLA_FRONTEND_PERSONAL_DETAILS_FORM = {
     "full_name": "Bob Merchandise",
     "postcode": "SW1H 9AJ",

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,7 +1,8 @@
 import os
 from configparser import ConfigParser
 from helper.helper_web import get_browser
- 
+
+
 def before_all(context):
     config = ConfigParser()
     print((os.path.join(os.getcwd(), 'setup.cfg')))

--- a/features/steps/test_steps.py
+++ b/features/steps/test_steps.py
@@ -1,6 +1,6 @@
 import re
 import time
-from features.constants import CLA_FRONTEND_PERSONAL_DETAILS_FORM
+from features.constants import CLA_FRONTEND_PERSONAL_DETAILS_FORM, CLA_FRONTEND_URL
 from selenium.webdriver.support.ui import Select
 from behave import *
 
@@ -8,7 +8,7 @@ from behave import *
 @given(u'that I am logged in')
 def step_impl(context):
     config = context.config.userdata
-    login_url = f"{config['cla_frontend_url']}/auth/login/"
+    login_url = f"{CLA_FRONTEND_URL}/auth/login/"
     context.helperfunc.open(login_url)
     form = context.helperfunc.find_by_name('login_frm')
     assert form is not None

--- a/helper/helper_web.py
+++ b/helper/helper_web.py
@@ -1,7 +1,9 @@
 from selenium import webdriver
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from helper.helper_base import HelperFunc
+from features.constants import SELENIUM_WEB_DRIVER_URL
+
  
 def get_browser(browser):
     if browser == "chrome":
-        return HelperFunc(webdriver.Remote("http://seleniumchrome:4444/wd/hub", DesiredCapabilities.CHROME))
+        return HelperFunc(webdriver.Remote(SELENIUM_WEB_DRIVER_URL, DesiredCapabilities.CHROME))


### PR DESCRIPTION
Add steps for running tests using local chrome driver
Update docker-compose.yaml to pass application and selenium urls to end-to-end tests through environment variables
Add constants for applications and selenium urls that are read from environment variables
Update tests and setup scripts to read applications and selenium urls from constants file