### PR TITLE
LGA-1970 - Set SENTRY_DSN to empty string if absent

### DIFF
--- a/behave/docker-compose.yml
+++ b/behave/docker-compose.yml
@@ -116,7 +116,7 @@ services:
       SMTP_PASSWORD: ""
       RAVEN_CONFIG_DSN: ""
       RAVEN_CONFIG_SITE: ""
-      SENTRY_DSN: ${SENTRY_DSN:-CHANGE_ME}
+      SENTRY_DSN: ${SENTRY_DSN:-}
       LAALAA_API_HOST: https://laa-legal-adviser-api-staging.apps.live-1.cloud-platform.service.justice.gov.uk
       MOJ_GA_ID: "UA-XXXXXXXX-X1"
       GDS_GA_ID: "UA-XXXXXXXX-X2"


### PR DESCRIPTION
The non-empty string value it was is not a valid value for its usage by
the Sentry SDK, so it's not a good default

Changing it to the empty string will allow `cla_public` to parse the default value, specifically allowing the suite to run when `SENTRY_DSN` is not set on CircleCI for the pipeline that's running, which it doesn't at the moment.

Other changes: the `SENTRY_DSN` has now been removed from this project's project settings on CircleCI, so its passing tests aren't relying on the old behaviour.