### PR TITLE
Feature/lga 1835 search for case and create new case

### DIFF
--- a/behave/features/assign_complete_case.feature
+++ b/behave/features/assign_complete_case.feature
@@ -17,5 +17,5 @@ Scenario: Attempt to assign an incomplete case
     And there is only one provider
     And I select 'Assign Provider'
     Then the case is assigned to the Specialist Provider
-    And I am taken to the call centre dashboard
+    And that I am on the 'call centre dashboard' page
     And the case does not show up on the call centre dashboard

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -58,4 +58,6 @@ CLA_CASE_PERSONAL_DETAILS_BACKEND_CHECK = {
     "Telephone": {"form_element_type": "p", "form_element_title": "Phone number", "backend_id": "mobile_phone"},
 
 }
+# Used for P5 - first step checks to see if we can find cases for a particular test user
+CLA_EXISTING_USER = "Anakin Skywalker"
 

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -59,5 +59,5 @@ CLA_CASE_PERSONAL_DETAILS_BACKEND_CHECK = {
 
 }
 # Used for P5 - first step checks to see if we can find cases for a particular test user
-CLA_EXISTING_USER = "Anakin Skywalker"
+CLA_EXISTING_USER = "Obi Wan Kenobi"
 

--- a/behave/features/search_for_user_create_new_case.feature
+++ b/behave/features/search_for_user_create_new_case.feature
@@ -1,0 +1,15 @@
+Feature: Search for existing user with a case and create new case
+    As a CHS operator, I need the ability to search for an existing case and look at the search result,
+    so I can select the relevant client case and proceed to create a new case for the client.
+    Search is by client name
+
+Background: Login
+    Given that I am logged in
+
+@create_case_existing_user
+Scenario: Create new case for existing user
+    Given that I am on the 'call centre dashboard' page
+    When I search for a client name with an existing case
+    Then I am taken to search results that shows cases belonging to that client
+    And I select to 'Create a case'
+

--- a/behave/features/search_for_user_create_new_case.feature
+++ b/behave/features/search_for_user_create_new_case.feature
@@ -11,5 +11,7 @@ Scenario: Create new case for existing user
     Given that I am on the 'call centre dashboard' page
     When I search for a client name with an existing case
     Then I am taken to search results that shows cases belonging to that client
-    And I select to 'Create a case'
+    And I select the name hyperlink for an existing case
+    And I select the button to create a case for the client originally searched for
+
 

--- a/behave/features/steps/assign_complete_case.py
+++ b/behave/features/steps/assign_complete_case.py
@@ -42,10 +42,12 @@ def step_impl_one_provider(context):
     context.provider_selected = headings[0].text
     assert len(headings) == 1
 
+
 @when(u'I select \'Assign Provider\'')
 def step_impl_assign_provider(context):
     context.case_id = context.helperfunc.find_by_css_selector('.CaseBar-caseNum a').text
     context.helperfunc.find_by_name("assign-provider").click()
+
 
 @then(u'the case is assigned to the Specialist Provider')
 def step_impl_case_assigned(context):
@@ -56,10 +58,6 @@ def step_impl_case_assigned(context):
     wait = WebDriverWait(context.helperfunc.driver(), 10)
     wait.until(wait_until_case_is_assigned)
 
-@then(u'I am taken to the call centre dashboard')
-def step_impl_taken_to_call_centre_dashboard(context):
-    current_path = context.helperfunc.get_current_path()
-    assert current_path == "/call_centre/"
 
 @then(u'the case does not show up on the call centre dashboard')
 def step_impl_case_removed_from_list(context):

--- a/behave/features/steps/search_for_user_create_new_case.py
+++ b/behave/features/steps/search_for_user_create_new_case.py
@@ -27,3 +27,19 @@ def step_impl(context):
         CLA_EXISTING_USER in case_row.text, case_rows), f"No cases associated with user {CLA_EXISTING_USER}"
 
 
+@then(u'I select the name hyperlink for an existing case')
+def step_impl(context):
+    # use the name hyperlink in the first row, we know there are cases because of previous steps
+    x_path = f'//div/table[@class="ListTable"]/tbody/tr/td/span/a'
+    assert context.helperfunc.driver().find_elements_by_xpath(x_path) is not None
+    context.helperfunc.driver().find_elements_by_xpath(x_path)[0].click()
+
+
+@then(u'I select the button to create a case for the client originally searched for')
+def step_impl(context):
+    # this button has the same id as when it just says 'create a case' so can use the original step
+    context.execute_steps(u'''
+        Given I select to 'Create a case'
+    ''')
+
+

--- a/behave/features/steps/search_for_user_create_new_case.py
+++ b/behave/features/steps/search_for_user_create_new_case.py
@@ -1,6 +1,7 @@
 from features.constants import CLA_EXISTING_USER, CLA_FRONTEND_URL
 from features.steps.common_steps import wait_until_page_is_loaded, assert_header_on_page
 
+
 @when(u'I search for a client name with an existing case')
 def step_impl(context):
     # find the search box
@@ -20,8 +21,6 @@ def step_impl(context):
         Given that I am on the 'call centre dashboard' page
     ''')
     # now check and see if we have cases that are assigned to this user
-    # TODO why is this returning too many rows??? Used elsewhere so need to follow up
-    # table = context.helperfunc.driver().find_element_by_css_selector(".ListTable")
     case_rows = context.helperfunc.driver().find_elements_by_xpath(f'//div/table[@class="ListTable"]/tbody/tr')
     assert case_rows is not None and filter(
         lambda case_row:

--- a/behave/features/steps/search_for_user_create_new_case.py
+++ b/behave/features/steps/search_for_user_create_new_case.py
@@ -1,0 +1,30 @@
+from features.constants import CLA_EXISTING_USER, CLA_FRONTEND_URL
+from features.steps.common_steps import wait_until_page_is_loaded, assert_header_on_page
+
+@when(u'I search for a client name with an existing case')
+def step_impl(context):
+    # find the search box
+    search_box = context.helperfunc.find_by_name("q")
+    user_name = CLA_EXISTING_USER
+    search_box.click()
+    # add in the user fullname to search for
+    search_box.send_keys(user_name)
+    # add in the user fullname to search for
+    search_submit = context.helperfunc.find_by_name("case-search-submit")
+    search_submit.click()
+
+
+@then(u'I am taken to search results that shows cases belonging to that client')
+def step_impl(context):
+    context.execute_steps(u'''
+        Given that I am on the 'call centre dashboard' page
+    ''')
+    # now check and see if we have cases that are assigned to this user
+    # TODO why is this returning too many rows??? Used elsewhere so need to follow up
+    # table = context.helperfunc.driver().find_element_by_css_selector(".ListTable")
+    case_rows = context.helperfunc.driver().find_elements_by_xpath(f'//div/table[@class="ListTable"]/tbody/tr')
+    assert case_rows is not None and filter(
+        lambda case_row:
+        CLA_EXISTING_USER in case_row.text, case_rows), f"No cases associated with user {CLA_EXISTING_USER}"
+
+

--- a/behave/features/steps/specialist_provider.py
+++ b/behave/features/steps/specialist_provider.py
@@ -43,8 +43,6 @@ def step_select_special_provider_case(context):
     table = context.helperfunc.driver().find_element_by_css_selector(".ListTable")
     # this will only return a link if the case hasn't already been accepted
     x_path = f".//tbody/tr[td/abbr[@title='Case status'][not(@class='Icon Icon--folderAccepted')]]/td/a[text()='{case_reference}']"
-    # import pdb
-    # pdb.set_trace()
     try:
         link = table.find_element_by_xpath(x_path)
         assert link is not None, f"Could not find unaccepted case {case_reference} on the dashboard"

--- a/behave/features/steps/specialist_provider.py
+++ b/behave/features/steps/specialist_provider.py
@@ -24,10 +24,10 @@ def step_on_spec_providers_dashboard(context):
 @step(u'there is a case available')
 def step_check_cases(context):
     # check there are cases available
-    table = context.helperfunc.driver().find_element_by_css_selector(".ListTable")
-    cases = table.find_elements_by_xpath('//tr')
-    # how many cases?
-    assert len(cases) > 0
+    # only carry on if there are cases that have not been accepted
+    x_path = f".//table[@class='ListTable']/tbody/tr/td/abbr[@title='Case status'][not(@class='Icon Icon--folderAccepted')]"
+    cases_not_accepted = context.helperfunc.driver().find_elements_by_xpath(x_path)
+    assert len(cases_not_accepted) > 0, f"No unaccepted cases"
 
 
 @step(u'I can view the client details')
@@ -41,12 +41,19 @@ def step_impl(context):
 def step_select_special_provider_case(context):
     case_reference = CLA_SPECIALIST_CASE_TO_ACCEPT
     table = context.helperfunc.driver().find_element_by_css_selector(".ListTable")
-    link = table.find_element_by_xpath(f"//tbody/tr/td/a[text()='{case_reference}']")
-    assert link is not None, f"Could not find case {case_reference} on the dashboard"
-    assert link.text == case_reference, f"Expected: {case_reference} - Found: {link.text}"
-
+    # this will only return a link if the case hasn't already been accepted
+    x_path = f".//tbody/tr[td/abbr[@title='Case status'][not(@class='Icon Icon--folderAccepted')]]/td/a[text()='{case_reference}']"
+    # import pdb
+    # pdb.set_trace()
+    try:
+        link = table.find_element_by_xpath(x_path)
+        assert link is not None, f"Could not find unaccepted case {case_reference} on the dashboard"
+        assert link.text == case_reference, f"Expected: {case_reference} - Found: {link.text}"
+    except NoSuchElementException:
+        assert False, f"Could not find unaccepted case {case_reference} on the dashboard"
     context.selected_case_ref = case_reference
     link.click()
+
 
 @given(u'I can view the case details and notes entered by the Operator')
 def step_impl(context):

--- a/behave/features/steps/test_steps.py
+++ b/behave/features/steps/test_steps.py
@@ -20,7 +20,7 @@ def step_impl(context):
     assert element is not None
 
 
-@given(u'that I am on the \'call centre dashboard\' page')
+@step(u'that I am on the \'call centre dashboard\' page')
 def step_impl(context):
     current_path = context.helperfunc.get_current_path()
     assert current_path == "/call_centre/"


### PR DESCRIPTION
P5 journey to search for cases associated with a particular user and then create a new case associated with that same user.

Tech debt:

Removed identical step from assign_complete_case for checking if on call centre dashboard

Specialist provider: Realised that this case would run even if the case had already been accepted. Added in checks so won't proceed if there are no unaccepted cases or if the particular case is already accepted.