### PR TITLE
LGA-1827 alternative help create user and case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ debug.log
 node_modules/
 
 .sass-cache/
+behave/feature_errors

--- a/behave/features/alternative_help.feature
+++ b/behave/features/alternative_help.feature
@@ -1,0 +1,13 @@
+Feature: Assign alternative help to out of scope case.
+
+Background: Login
+    Given that I am logged in
+
+@althelp
+Scenario: Create user and out of scope case
+    GIVEN  I am on the call centre dashboard
+    WHEN I select to 'Create a case'
+    THEN I complete the users details with 'Test Dummy User' details
+    THEN I navigate the call centre dashboard
+    THEN I go back to the previous case
+    THEN I should see the users previously entered details

--- a/behave/features/alternative_help.feature
+++ b/behave/features/alternative_help.feature
@@ -5,7 +5,7 @@ Background: Login
 
 @althelp
 Scenario: Create user and out of scope case
-    GIVEN  I am on the call centre dashboard
+    GIVEN that I am on the 'call centre dashboard' page
     WHEN I select to 'Create a case'
     THEN I complete the users details with 'Test Dummy User' details
     THEN I navigate the call centre dashboard

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -31,6 +31,21 @@ CLA_FRONTEND_PERSONAL_DETAILS_FORM = {
     "source": "Phone"
 }
 
+CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP = {
+    "full_name": "Test Dummy User",
+    "postcode": "SW1H 9AJ",
+    "street": "102 Petty France",
+    "mobile_phone": "020 3334 3555",
+    "email": "102pettyfrance@digital.justice.gov.uk",
+    "dob_day": "1",
+    "dob_month": "1",
+    "dob_year": "1990",
+    "ni_number": "PA102030F",
+    "adaptations": "No adaptations required",
+    "media_code": "Don't Know",
+    "source": "Phone"
+}
+
 CLA_MEANS_TEST_PERSONAL_DETAILS_FORM = {
     "full_name": {"form_element_id": "full_name", "form_element_value": "John Smith"},
     "postcode": {"form_element_id": "address-post_code", "form_element_value": "SW1H 9AJ"},

--- a/behave/features/create_case_and_user.feature
+++ b/behave/features/create_case_and_user.feature
@@ -17,7 +17,7 @@ Background: Login
 
 @createuser
 Scenario: Create a Case and new User.
-    Given that I am on the 'call centre dashboard' page
+    Given I am on the call centre dashboard
     When I select to 'Create a case'
     Then I am taken to the 'case details' page
     And I select 'Create new user'

--- a/behave/features/create_case_and_user.feature
+++ b/behave/features/create_case_and_user.feature
@@ -17,7 +17,7 @@ Background: Login
 
 @createuser
 Scenario: Create a Case and new User.
-    Given I am on the call centre dashboard
+    Given that I am on the 'call centre dashboard' page
     When I select to 'Create a case'
     Then I am taken to the 'case details' page
     And I select 'Create new user'

--- a/behave/features/steps/alternative_help.py
+++ b/behave/features/steps/alternative_help.py
@@ -1,0 +1,33 @@
+from behave import *
+from features.constants import CLA_FRONTEND_URL, CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP
+
+
+@then(u'I complete the users details with \'Test Dummy User\' details')
+def step_impl(context):
+    context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP
+    context.execute_steps(u'''
+        When I select 'Create new user'
+        And enter the client's personal details
+        And I click the save button on the screen
+    ''')
+
+
+@then(u'I navigate the call centre dashboard')
+def step_impl(context):
+    url = f"{CLA_FRONTEND_URL}/call_centre/"
+    context.helperfunc.open(url)
+
+
+@then(u'I go back to the previous case')
+def step_impl(context):
+    assert context.case_reference, "Context is missing case reference"
+    url = f"{CLA_FRONTEND_URL}/call_centre/{context.case_reference}/"
+    context.helperfunc.open(url)
+
+
+@then(u'I should see the users previously entered details')
+def step_impl(context):
+    context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP
+    context.execute_steps(u'''
+        Then I will see the users details
+    ''')


### PR DESCRIPTION
- Make the `And enter the client's personal details` step reusable by getting the form details from the context
- Save the case reference when a new case is created in the `When I select to 'Create a case'`
- Create user and case for assigning alternative help