### PR TITLE
LGA 1829 out of scope diagnosis assign alternative help succeeds

### DIFF
--- a/behave/features/alternative_help.feature
+++ b/behave/features/alternative_help.feature
@@ -15,7 +15,7 @@ Scenario: Assign alternative help for out of scope user with necessary details
     AND I select the diagnosis <category> and click next <number> times
     | category                                                | number |
     | Crime                                                   | 2      |
-    THEN I get an OUTOFSCOPE decision
+    THEN I get an "OUTOFSCOPE" decision
     WHEN I select 'Assign Alternative Help'
     THEN I am taken to the "Alternative help" page for the case located at "/alternative_help/"
 

--- a/behave/features/alternative_help.feature
+++ b/behave/features/alternative_help.feature
@@ -4,7 +4,7 @@ Background: Login
     Given that I am logged in
 
 @althelp
-Scenario: Create user and out of scope case
+Scenario: Assign alternative help for out of scope user with necessary details
     GIVEN that I am on the 'call centre dashboard' page
     WHEN I select to 'Create a case'
     THEN I complete the users details with 'Test Dummy User' details
@@ -16,3 +16,6 @@ Scenario: Create user and out of scope case
     | category                                                | number |
     | Crime                                                   | 2      |
     THEN I get an OUTOFSCOPE decision
+    WHEN I select 'Assign Alternative Help'
+    THEN I am taken to the "Alternative help" page for the case located at "/alternative_help/"
+

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -1,5 +1,6 @@
 import os
 
+MAX_TRIES = 2
 BROWSER = os.environ.get("BROWSER")
 ARTIFACTS_DIRECTORY = os.environ.get("ARTIFACTS_DIRECTORY")
 

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -1,6 +1,5 @@
 import os
 
-MAX_TRIES = 2
 BROWSER = os.environ.get("BROWSER")
 ARTIFACTS_DIRECTORY = os.environ.get("ARTIFACTS_DIRECTORY")
 

--- a/behave/features/diagnosis_debt_court_proceedings.feature
+++ b/behave/features/diagnosis_debt_court_proceedings.feature
@@ -9,7 +9,8 @@ Background: Login
 
 @in_scope_debt_court
 Scenario: Given an INSCOPE decision when selecting debt and court proceedings
-    Given I am taken to the "call centre" case details page
+    Given that I am on the 'call centre dashboard' page
+    And I select to 'Create a case'
     And a client with an existing case is added to it
     When I select ‘Create Scope Diagnosis'
     And I select the diagnosis <category> and click next <number> times
@@ -17,6 +18,6 @@ Scenario: Given an INSCOPE decision when selecting debt and court proceedings
         | Debt and housing - loss of home                         | 1      |
         | Homeless or at risk of becoming homeless within 56 days | 1      |
         | A court has issued possession proceedings               | 1      |
-    Then I get an INSCOPE decision
+    And I get an "INSCOPE" decision
     And select 'Create financial assessment'
     Then I am taken to the Finances tab with the ‘Details’ sub-tab preselected

--- a/behave/features/diagnosis_discrimination.feature
+++ b/behave/features/diagnosis_discrimination.feature
@@ -15,6 +15,6 @@ Scenario: Given an INSCOPE decision when selecting discrimination at work
     | Direct discrimination                                   | 1      |
     | Disability                                              | 1      |
     | Work                                                    | 1      |
-    Then I get an INSCOPE decision
+    Then I get an "INSCOPE" decision
     And select 'Create financial assessment'
     Then I am taken to the Finances tab with the ‘Details’ sub-tab preselected

--- a/behave/features/steps/alternative_help.py
+++ b/behave/features/steps/alternative_help.py
@@ -1,5 +1,6 @@
 from behave import *
 from features.constants import CLA_FRONTEND_URL, CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP
+from selenium.webdriver.common.by import By
 
 
 @then(u'I complete the users details with \'Test Dummy User\' details')
@@ -31,3 +32,12 @@ def step_impl(context):
     context.execute_steps(u'''
         Then I will see the users details
     ''')
+
+
+@when(u'I select \'Assign Alternative Help\'')
+def step_impl(context):
+    # for some reason these seem to return stale element errors
+    # use the wrapper function
+    x_path = f".//a[@title='Assign alternative help']"
+    context.helperfunc.click_button(By.XPATH, x_path)
+

--- a/behave/features/steps/assign_incomplete_case.py
+++ b/behave/features/steps/assign_incomplete_case.py
@@ -23,7 +23,7 @@ def step_impl(context):
     context.execute_steps(u'''
         When I select ‘Create Scope Diagnosis'
         And I select the categories Discrimination, Direct Discrimination, Disability, Work
-        Then I get an INSCOPE decision
+        Then I get an "INSCOPE" decision
         And select 'Create financial assessment'
     ''')
 

--- a/behave/features/steps/cla_select_digital_case_by_call_back.py
+++ b/behave/features/steps/cla_select_digital_case_by_call_back.py
@@ -1,4 +1,4 @@
-from features.steps.common_steps import assert_header_on_page, wait_until_page_is_loaded, compare_client_details_with_backend
+from features.steps.common_steps import compare_client_details_with_backend
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import StaleElementReferenceException
 

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -1,14 +1,24 @@
+import re
 import time
 from behave import *
-from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.wait import WebDriverWait
-from features.constants import CLA_CASE_PERSONAL_DETAILS_BACKEND_CHECK
+from features.constants import CLA_CASE_PERSONAL_DETAILS_BACKEND_CHECK, MAX_TRIES
+from selenium.webdriver.common.by import By
 
 
 def assert_header_on_page(title, context):
-    heading = context.helperfunc.find_by_xpath('//h1')
-    assert heading is not None
-    assert heading.text == title
+    # occasionally there could be more than one h1 on the page. In most cases we want the first one
+    # Go through the list to check all h1 elements
+    headings = context.helperfunc.find_many_by_xpath('//h1')
+    assert headings is not None
+    found_heading = False
+    # check each of the headings to see if we have a match
+    for heading in headings:
+        if heading.text == title:
+            found_heading = True
+    error_message = f"{heading.text} not found on {context.helperfunc.get_current_path()}"
+    assert found_heading, error_message
 
 
 def wait_until_page_is_loaded(path, context):
@@ -57,6 +67,18 @@ def step_check_page(context, page, header):
     assert_header_on_page(header, context)
 
 
+@step(u'I am taken to the "{header}" page for the case located at "{sub_page}"')
+def step_impl(context, sub_page, header):
+    # can't use the above step because there is a case reference in the url
+    # find the first part of the url
+    current_path = context.helperfunc.get_current_path()
+    path = re.compile(r"(^/call_centre/\w{2}-\d{4}-\d{4})")
+    match = path.search(current_path).group(1)
+    required_page = f"{match}{sub_page}"
+    wait_until_page_is_loaded(required_page, context)
+    assert_header_on_page(header, context)
+
+
 @step(u'I am taken to the "{type_of_user}" case details page')
 def step_on_case_details_page(context, type_of_user):
     # get the case reference
@@ -81,7 +103,7 @@ def step_on_case_details_page(context, type_of_user):
         # can use the function with the regex on test_steps
         # this will fail if this is for a specialist provider
         context.execute_steps(u'''
-               Given I select to 'Create a case'
+               I am taken to the 'case details' page
            ''')
 
 
@@ -102,16 +124,10 @@ def step_impl(context):
         # find the radio input next to the text of the category
         x_path = f".//p[contains(text(),'{category_text}')]//ancestor::label/input[@type='radio']"
         # for some reason these seem to return stale element errors
-        try:
-            context.helperfunc.find_by_xpath(x_path).click()
-        except StaleElementReferenceException:
-            context.helperfunc.find_by_xpath(x_path).click()
+        context.helperfunc.click_button(By.XPATH, x_path)
         # now click next the correct number of times (normally 1)
         for _ in range(int(next_number)):
-            try:
-                context.helperfunc.find_by_name("diagnosis-next").click()
-            except StaleElementReferenceException:
-                context.helperfunc.find_by_name("diagnosis-next").click()
+            context.helperfunc.click_button(By.NAME, "diagnosis-next")
             # This is required because the diagnosis-next button on the current page and next page have the same name
             # Without this sleep it will just find the same button and click it again instead of waiting for new button
             # to load

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -71,10 +71,11 @@ def step_check_page(context, page, header):
 def step_impl(context, sub_page, header):
     # can't use the above step because there is a case reference in the url
     # find the first part of the url
+    # sub_page will already have / at start and possibly at end as required
     current_path = context.helperfunc.get_current_path()
-    path = re.compile(r"(^/call_centre/\w{2}-\d{4}-\d{4})")
-    match = path.search(current_path).group(1)
-    required_page = f"{match}{sub_page}"
+    reg_ex = re.compile(r"(\w{2}-\d{4}-\d{4})")
+    case_reference_id = reg_ex.search(current_path).group(1)
+    required_page = f"/call_centre/{case_reference_id}{sub_page}"
     wait_until_page_is_loaded(required_page, context)
     assert_header_on_page(header, context)
 
@@ -103,7 +104,7 @@ def step_on_case_details_page(context, type_of_user):
         # can use the function with the regex on test_steps
         # this will fail if this is for a specialist provider
         context.execute_steps(u'''
-               I am taken to the 'case details' page
+              Given I am taken to the 'case details' page
            ''')
 
 
@@ -144,13 +145,7 @@ def step_impl(context):
     wait.until(wait_for_diagnosis_delete_btn)
 
 
-@then(u'I get an INSCOPE decision')
-def step_impl(context):
+@step(u'I get an "{scope}" decision')
+def step_impl(context, scope):
     text = context.helperfunc.find_by_name('diagnosis-form').text
-    assert "INSCOPE" in text
-
-
-@then(u'I get an OUTOFSCOPE decision')
-def step_impl(context):
-    text = context.helperfunc.find_by_name('diagnosis-form').text
-    assert "OUTOFSCOPE" in text
+    assert scope in text

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -3,7 +3,7 @@ import time
 from behave import *
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.wait import WebDriverWait
-from features.constants import CLA_CASE_PERSONAL_DETAILS_BACKEND_CHECK, MAX_TRIES
+from features.constants import CLA_CASE_PERSONAL_DETAILS_BACKEND_CHECK
 from selenium.webdriver.common.by import By
 
 

--- a/behave/features/steps/search_for_user_create_new_case.py
+++ b/behave/features/steps/search_for_user_create_new_case.py
@@ -1,5 +1,4 @@
-from features.constants import CLA_EXISTING_USER, CLA_FRONTEND_URL
-from features.steps.common_steps import wait_until_page_is_loaded, assert_header_on_page
+from features.constants import CLA_EXISTING_USER
 
 
 @when(u'I search for a client name with an existing case')

--- a/behave/features/steps/specialist_provider.py
+++ b/behave/features/steps/specialist_provider.py
@@ -1,5 +1,5 @@
 from features.constants import CLA_FRONTEND_URL, CLA_SPECIALIST_PROVIDERS_NAME, CLA_SPECIALIST_CASE_TO_ACCEPT
-from features.steps.common_steps import wait_until_page_is_loaded, assert_header_on_page, compare_client_details_with_backend
+from features.steps.common_steps import compare_client_details_with_backend
 from selenium.common.exceptions import NoSuchElementException
 
 

--- a/behave/features/steps/test_steps.py
+++ b/behave/features/steps/test_steps.py
@@ -2,6 +2,7 @@ import re
 from features.constants import CLA_FRONTEND_PERSONAL_DETAILS_FORM, CLA_FRONTEND_URL
 from selenium.webdriver.support.ui import Select, WebDriverWait
 from behave import *
+from selenium.webdriver.common.by import By
 
 
 @given(u'that I am logged in')
@@ -27,11 +28,12 @@ def step_impl(context):
 
 @step(u'I select to \'Create a case\'')
 def step_impl(context):
-    context.helperfunc.find_by_id("create_case").click()
+    # wrap click() to avoid StaleElementException
+    context.helperfunc.click_button(By.ID, "create_case")
     context.case_reference = context.helperfunc.find_by_css_selector('h1.CaseBar-caseNum a').text
 
 
-@then(u'I am taken to the \'case details\' page')
+@step(u'I am taken to the \'case details\' page')
 def step_impl(context):
     assert context.helperfunc.find_by_xpath("//header/h1").text == "Case details"
     current_path = context.helperfunc.get_current_path()

--- a/behave/helper/helper_base.py
+++ b/behave/helper/helper_base.py
@@ -29,7 +29,7 @@ class HelperFunc(object):
     def close(self):
         self._driver.quit()
 
-    # Takes screenshot, specifically it grabs the entire the entire body of the page.
+    # Takes screenshot, specifically it grabs the entire body of the page.
     def take_screenshot(self, scenario_file_path):
         element = self._driver.find_element_by_tag_name('body')
         element.screenshot(scenario_file_path)
@@ -84,7 +84,6 @@ class HelperFunc(object):
         return self.call_centre_backend.get_future_callbacks()
 
     def click_button(self, selector_type, selector):
-        # broaden this so it uses other types of find as well, eg fnd by name
         def retry_func(func):
             for i in range(MAX_TRIES):
                 try:

--- a/behave/helper/helper_base.py
+++ b/behave/helper/helper_base.py
@@ -84,20 +84,14 @@ class HelperFunc(object):
         return self.call_centre_backend.get_future_callbacks()
 
     def click_button(self, selector_type, selector):
-        def retry_func(func):
-            for i in range(MAX_TRIES):
-                try:
-                    return func()
-                except Exception as e:
-                    if i >= MAX_TRIES - 1:
-                        raise e
 
-        def click_button_helper(chosen_selector_path_type, chosen_selector_path, delay=10):
-            WebDriverWait(self._driver, delay,
-                          ignored_exceptions=StaleElementReferenceException).until(
-                        EC.visibility_of_element_located((
-                            chosen_selector_path_type, chosen_selector_path))).click()
+        def wait_until_button_is_clicked(*args):
+            try:
+                self._driver.find_element(selector_type, selector).click()
+                return True
+            except StaleElementReferenceException:
+                return False
 
-        retry_func(lambda: click_button_helper(selector_type, selector))
-
+        wait = WebDriverWait(self._driver, 10)
+        wait.until(wait_until_button_is_clicked)
 

--- a/behave/helper/helper_base.py
+++ b/behave/helper/helper_base.py
@@ -4,7 +4,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import StaleElementReferenceException
 from helper.backend import Backend
-from constants import CALL_CENTRE_ZONE, MAX_TRIES
+from constants import CALL_CENTRE_ZONE
 
 
 class HelperFunc(object):


### PR DESCRIPTION
Further steps for user journey p6 and refactoring

Created common functionality to deal with clicking buttons - allows for stale element exception.

Removed unused import statements and updates assert_header_on_page function to allow for more than one h1 element.

Changed I am taken to the "{type_of_user}" case details page as I think it was using the wrong step at the end.

Refactored "inscope" and "outofscope" methods so use same step.

Updated the steps at start of the @in_scope_debt_court to match other scenarios.
