### PR TITLE
LGA-2136 Alternative help fails

### DIFF
--- a/behave/features/alternative_help.feature
+++ b/behave/features/alternative_help.feature
@@ -3,14 +3,14 @@ Feature: Assign alternative help to out of scope case.
 Background: Login
     Given that I am logged in
 
-@althelp
+@alt_help_succeeds
 Scenario: Assign alternative help for out of scope user with necessary details
     GIVEN I am on the 'call centre dashboard' page
     WHEN I select to 'Create a case'
-    AND I complete the users details with 'Test Dummy User' details
+    AND I complete the users details with FULL details
     AND I navigate back to the call centre dashboard
     AND I go back to the previous case
-    AND I see the users previously entered details
+    AND I see the users previously entered FULL details
     AND I select ‘Create Scope Diagnosis'
     AND I select the diagnosis <category> and click next <number> times
     | category                                                | number |
@@ -21,4 +21,19 @@ Scenario: Assign alternative help for out of scope user with necessary details
     AND I am taken to the "Alternative help" page for the case located at "/alternative_help/"
     THEN I select "Face to Face" and I am taken to a new tab displaying FALA
 
+@alt_help_fails_insufficient_user_details
+Scenario: Assign alternative help for out of scope user without postcode or phone number
+    GIVEN I am on the 'call centre dashboard' page
+    WHEN I select to 'Create a case'
+    AND I complete the users details with LIMITED details
+    AND I navigate back to the call centre dashboard
+    AND I go back to the previous case
+    AND I select ‘Create Scope Diagnosis'
+    AND I select the diagnosis <category> and click next <number> times
+    | category                                                | number |
+    | Crime                                                   | 2      |
+    AND I get an "OUTOFSCOPE" decision
+    #This is the icon in the top RH corner
+    AND I click on the Assign Alternative Help icon
+    THEN a Missing Information validation message is displayed to the user
 

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -61,35 +61,6 @@ CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP = {
     "source": "Phone"
     }
 }
-# CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP_FAILS = {
-#     "full_name": "Rey Skywalker incomplete details",
-#     "postcode": "",
-#     "street": "102 Petty France",
-#     "mobile_phone": "",
-#     "email": "102pettyfrance@digital.justice.gov.uk",
-#     "dob_day": "1",
-#     "dob_month": "1",
-#     "dob_year": "1990",
-#     "ni_number": "PA102030F",
-#     "adaptations": "No adaptations required",
-#     "media_code": "Don't Know",
-#     "source": "Phone"
-# }
-#
-# CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP_SUCCEEDS = {
-#     "full_name": "Test Dummy User",
-#     "postcode": "SW1H 9AJ",
-#     "street": "102 Petty France",
-#     "mobile_phone": "020 3334 3555",
-#     "email": "102pettyfrance@digital.justice.gov.uk",
-#     "dob_day": "1",
-#     "dob_month": "1",
-#     "dob_year": "1990",
-#     "ni_number": "PA102030F",
-#     "adaptations": "No adaptations required",
-#     "media_code": "Don't Know",
-#     "source": "Phone"
-# }
 
 CLA_MEANS_TEST_PERSONAL_DETAILS_FORM = {
     "full_name": {"form_element_id": "full_name", "form_element_value": "John Smith"},

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -32,6 +32,7 @@ CLA_FRONTEND_PERSONAL_DETAILS_FORM = {
 }
 
 CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP = {
+    "FULL": {
     "full_name": "Test Dummy User",
     "postcode": "SW1H 9AJ",
     "street": "102 Petty France",
@@ -44,7 +45,51 @@ CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP = {
     "adaptations": "No adaptations required",
     "media_code": "Don't Know",
     "source": "Phone"
+    },
+    "LIMITED": {
+    "full_name": "Rey Skywalker incomplete details",
+    "postcode": "",
+    "street": "102 Petty France",
+    "mobile_phone": "",
+    "email": "102pettyfrance@digital.justice.gov.uk",
+    "dob_day": "1",
+    "dob_month": "1",
+    "dob_year": "1990",
+    "ni_number": "PA102030F",
+    "adaptations": "No adaptations required",
+    "media_code": "Don't Know",
+    "source": "Phone"
+    }
 }
+# CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP_FAILS = {
+#     "full_name": "Rey Skywalker incomplete details",
+#     "postcode": "",
+#     "street": "102 Petty France",
+#     "mobile_phone": "",
+#     "email": "102pettyfrance@digital.justice.gov.uk",
+#     "dob_day": "1",
+#     "dob_month": "1",
+#     "dob_year": "1990",
+#     "ni_number": "PA102030F",
+#     "adaptations": "No adaptations required",
+#     "media_code": "Don't Know",
+#     "source": "Phone"
+# }
+#
+# CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP_SUCCEEDS = {
+#     "full_name": "Test Dummy User",
+#     "postcode": "SW1H 9AJ",
+#     "street": "102 Petty France",
+#     "mobile_phone": "020 3334 3555",
+#     "email": "102pettyfrance@digital.justice.gov.uk",
+#     "dob_day": "1",
+#     "dob_month": "1",
+#     "dob_year": "1990",
+#     "ni_number": "PA102030F",
+#     "adaptations": "No adaptations required",
+#     "media_code": "Don't Know",
+#     "source": "Phone"
+# }
 
 CLA_MEANS_TEST_PERSONAL_DETAILS_FORM = {
     "full_name": {"form_element_id": "full_name", "form_element_value": "John Smith"},

--- a/behave/features/diagnosis.feature
+++ b/behave/features/diagnosis.feature
@@ -1,8 +1,5 @@
-Feature: Correct decision on debt and court proceedings.
-    Confirms that when a case with the scope diagnosis of 'Debt and housing - loss of home,
-    Homeless or at risk of becoming homeless within 56 days, A court has issued possession proceedings' is selected that you
-    get an INSCOPE decision.
-    This scenario will reuse lots of the steps from the discrimination diagnosis P1 cases
+Feature: Give a decision for various diagnosis journeys
+Confirms that get INSCOPE or OUTOFSCOPE as required
 
 Background: Login
     Given that I am logged in

--- a/behave/features/steps/alternative_help.py
+++ b/behave/features/steps/alternative_help.py
@@ -64,7 +64,7 @@ def step_impl(context, face_to_face_text):
     assert last_hyperlink_selected == context.helperfunc.driver().current_url
 
 
-@then(u'a Missing Information validation message is displayed to the user')
+@step(u'a Missing Information validation message is displayed to the user')
 def step_impl(context):
     alert = context.helperfunc.find_by_css_selector("div[class='modal-dialog '")
     error_text = "You must collect at least a name and a postcode or phone number"

--- a/behave/features/steps/alternative_help.py
+++ b/behave/features/steps/alternative_help.py
@@ -1,12 +1,15 @@
 from behave import *
-from features.constants import CLA_FRONTEND_URL, CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP
+from features.constants import CLA_FRONTEND_URL, CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP, CLA_FRONTEND_PERSONAL_DETAILS_FORM
 from selenium.webdriver.common.by import By
 from common_steps import click_on_hyperlink, switch_to_new_tab
 
 
-@step(u'I complete the users details with \'Test Dummy User\' details')
-def step_impl(context):
-    context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP
+@step(u'I complete the users details with {user_choice:w} details')
+def step_impl(context, user_choice):
+    try:
+        context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP[user_choice]
+    except KeyError:
+        context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM
     context.execute_steps(u'''
         When I select 'Create new user'
         And enter the client's personal details
@@ -27,9 +30,12 @@ def step_impl(context):
     context.helperfunc.open(url)
 
 
-@step(u'I see the users previously entered details')
-def step_impl(context):
-    context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP
+@step(u'I see the users previously entered {user_choice:w} details')
+def step_impl(context, user_choice):
+    try:
+        context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM_ALTERNATIVE_HELP[user_choice]
+    except KeyError:
+        context.personal_details_form = CLA_FRONTEND_PERSONAL_DETAILS_FORM
     context.execute_steps(u'''
         Then I will see the users details
     ''')
@@ -56,4 +62,11 @@ def step_impl(context, face_to_face_text):
     context.helperfunc.driver().switch_to.window(new_tab)
     # check the url
     assert last_hyperlink_selected == context.helperfunc.driver().current_url
+
+
+@then(u'a Missing Information validation message is displayed to the user')
+def step_impl(context):
+    alert = context.helperfunc.find_by_css_selector("div[class='modal-dialog '")
+    error_text = "You must collect at least a name and a postcode or phone number"
+    assert error_text in alert.text
 


### PR DESCRIPTION
Added in extra step for when alternative help cannot be assigned.
Tech debt:
Updated the steps to see user details.
Changed the description of diagnosis.feature to be more generic as it now has two scenarios.