### PR TITLE
Feauture/lga 2183 call someone else

### DIFF
--- a/behave/features/cla_contact_us.feature
+++ b/behave/features/cla_contact_us.feature
@@ -18,3 +18,16 @@ Scenario: contact us journey to contact civil legal advice page / form
     And I select the contact option 'I’ll call CLA'
     And I select 'Submit details'
     Then I am taken to the "Your details have been submitted" page located on "/result/confirmation"
+
+# Journey P9, Ticket (LGA-2183)
+@cla-contact-us-call-someone-else
+Scenario: contact us journey, selecting 'call someone else instead of me' option
+  Given I am on the Contact Civil Legal Advice page
+  When I enter a name in the 'Your full name' field
+  And I select the contact option 'Call someone else instead of me'
+  And I enter the full name of the person to call
+  And I select "Family member or friend" from the 'Relationship to you' drop down options
+  And I enter the phone number of the person to call back
+  And I select 'Call today'
+  And I select 'Submit details'
+  Then I am taken to the "We will call you back" page located on "/result/confirmation"

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -95,5 +95,8 @@ CLA_CASE_DETAILS_INNER_TAB = {"Details": 1,
                               "Finances": 2,
                               "Income": 3,
                               "Expenses": 4}
+# P9 users for contact us options
 ClA_CONTACT_US_USER = "Nathan Drake"
+CLA_CONTACT_US_USER_PERSON_TO_CALL = "Elena Fisher"
+
 MINIMUM_SLEEP_SECONDS = 2

--- a/behave/features/steps/cla_contact_us.py
+++ b/behave/features/steps/cla_contact_us.py
@@ -1,5 +1,8 @@
 from behave import *
-from features.constants import ClA_CONTACT_US_USER
+from features.constants import ClA_CONTACT_US_USER, CLA_CONTACT_US_USER_PERSON_TO_CALL, CLA_NUMBER
+from selenium.webdriver.support.ui import Select
+from selenium.common.exceptions import StaleElementReferenceException
+
 
 @step(u'I select \'Contact us\' from the banner')
 def step_impl(context):
@@ -39,3 +42,63 @@ def step_impl(context):
     assert full_name_input.get_attribute('value') == value
 
 
+@step(u'I am on the Contact Civil Legal Advice page')
+def step_impl(context):
+    context.execute_steps(u'''
+        Given I select 'Contact us' from the banner
+        And I select <question> from the contact civil legal advice page
+            | question                       |
+            | I’d prefer to speak to someone |
+        And I click 'continue to contact CLA'
+        And I am taken to the "Contact Civil Legal Advice" page located on "/contact"
+    ''')
+
+
+@step(u'I select the contact option \'Call someone else instead of me\'')
+def step_impl(context):
+    # input can not be found without first finding form
+    context.callback_form = context.helperfunc.find_by_xpath("//form")
+    callback_element = context.callback_form.find_element_by_xpath(f'//input[@value="thirdparty"]')
+    assert callback_element is not None
+    callback_element.click()
+    assert callback_element.get_attribute("value") == "thirdparty"
+
+
+@step(u'I select \'Call today\'')
+def step_impl(context):
+    # input can not be found without first finding form
+    context.callback_form = context.helperfunc.find_by_xpath("//form")
+    call_today = context.callback_form.find_element_by_xpath(f'//input[@value="today"]'
+                                                             f'[@id="thirdparty-time-specific_day-0"]')
+    assert call_today is not None
+    call_today.click()
+    assert call_today.get_attribute("value") == "today"
+
+
+# call someone else instead of me name input field
+@step(u'I enter the full name of the person to call')
+def step_impl(context):
+    value = CLA_CONTACT_US_USER_PERSON_TO_CALL
+    full_name_input = context.helperfunc.find_by_xpath("//input[@id='thirdparty-full_name']")
+    full_name_input.send_keys(value)
+    assert full_name_input.get_attribute('value') == value
+
+
+# call someone else instead of me phone number input field
+@step(u'I enter the phone number of the person to call back')
+def step_impl(context):
+    value = CLA_NUMBER
+    full_name_input = context.helperfunc.find_by_xpath("//input[@id='thirdparty-contact_number']")
+    full_name_input.send_keys(value)
+    assert full_name_input.get_attribute('value') == value
+
+
+@step(u'I select "{option}" from the \'Relationship to you\' drop down options')
+def step_impl(context, option):
+    context.callback_form = context.helperfunc.find_by_xpath("//form")
+    select = Select(context.callback_form.find_element_by_xpath(f'//select[@id="thirdparty-relationship"]'))
+    assert select is not None
+    try:
+        select.select_by_visible_text(option)
+    except StaleElementReferenceException:
+        assert False, f"Could find {option} in \'Relationship to you select\' options"


### PR DESCRIPTION
1) Added step to reuse landing on the contact us form page.
2) New steps for filling in someone else to contact name and number
3) New step for selecting radio button 
4) Re-used existing steps to confirm text and page is correct.