### PR TITLE
Adding static file value in docker-compose clabackend values

### DIFF
--- a/behave/docker-compose.yml
+++ b/behave/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       LOAD_TEST_DATA: "True"
       LOAD_END_TO_END_FIXTURES: "True"
       ADMIN_USER: cla_admin
+      STATIC_FILES_BACKEND: local
       ADMIN_PASSWORD: cla_admin
       ALLOWED_HOSTS: "*"
 


### PR DESCRIPTION
Added a new config value in docker-compose.yml with STATIC_FILE_BACKEND to allow static files to built and used in docker builds. 