### PR TITLE
Wait for tabs to be clickable

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -13,6 +13,7 @@ def before_all(context):
     
     # Dir to output test artifacts
     context.artifacts_dir = ARTIFACTS_DIRECTORY
+    helper_func.maximize();
 
 @capture
 def after_scenario(context, scenario):

--- a/behave/features/steps/assign_case.py
+++ b/behave/features/steps/assign_case.py
@@ -2,7 +2,6 @@ from behave import *
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import StaleElementReferenceException
 from features.constants import MATTER_TYPE_1, MATTER_TYPE_2, CLA_FRONTEND_URL
-from selenium.webdriver.common.by import By
 
 @given(u'case notes are empty')
 def step_impl(context):
@@ -112,7 +111,6 @@ def step_impl(context):
 def step_impl(context):
     context.helperfunc.find_by_partial_link_text("Assign").click()
 
-
 @then(u'I get a message with the text "Case notes must be added to close a case"')
 def step_impl(context):
     alert = context.helperfunc.find_by_css_selector("div[class='modal-dialog '")
@@ -152,8 +150,15 @@ def step_impl_matter_type2(context):
 
 @when(u'there is only one provider')
 def step_impl_one_provider(context):
-    # Find matter type 2 wrapper and focus on it
     form = context.helperfunc.find_by_name('assign_provider_form')
+
+    # Providers are loaded via ajax after clicking the assign tab
+    def wait_for_assign_providers_to_load(*args):
+        return form.find_element_by_css_selector('div.ContactBlock') is not None
+    wait = WebDriverWait(context.helperfunc.driver(), 10)
+    wait.until(wait_for_assign_providers_to_load)
+
+    # Find matter type 2 wrapper and focus on it
     headings = form.find_elements_by_css_selector("h2.ContactBlock-heading")
     context.provider_selected = headings[0].text
     assert len(headings) == 1

--- a/behave/features/steps/assign_case.py
+++ b/behave/features/steps/assign_case.py
@@ -111,6 +111,7 @@ def step_impl(context):
 def step_impl(context):
     context.helperfunc.find_by_partial_link_text("Assign").click()
 
+
 @then(u'I get a message with the text "Case notes must be added to close a case"')
 def step_impl(context):
     alert = context.helperfunc.find_by_css_selector("div[class='modal-dialog '")

--- a/behave/features/steps/means_test.py
+++ b/behave/features/steps/means_test.py
@@ -34,10 +34,7 @@ def step_impl(context, tab_name):
     actions.move_to_element(page.find_by_xpath(xpath_scroll)).perform()
 
     xpath = f"//ul[@id='pills-section-list']/li/a[text()='{tab_name}']"
-    WebDriverWait(page.driver(), 10).until(EC.element_to_be_clickable((By.XPATH, xpath)))
-    page.find_by_xpath(xpath).click()
-
-    page.find_by_xpath(f"//ul[@id='pills-section-list']/li/a[text()='{tab_name}']").click()
+    WebDriverWait(page.driver(), 10).until(EC.element_to_be_clickable((By.XPATH, xpath))).click()
 
     def wait_for_active_tab(*args):
         return tab_name in context.helperfunc.find_by_class("Pills-pill.is-active").text

--- a/behave/features/steps/means_test.py
+++ b/behave/features/steps/means_test.py
@@ -1,7 +1,8 @@
 from behave import *
 from selenium.webdriver.common.action_chains import ActionChains
-from features.constants import CLA_CASE_DETAILS_INNER_TAB, MINIMUM_SLEEP_SECONDS
 from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
 
 
 def set_income_input_field_by_label(context, label, value):
@@ -31,6 +32,11 @@ def step_impl(context, tab_name):
     page = context.helperfunc
     actions = ActionChains(page.driver())
     actions.move_to_element(page.find_by_xpath(xpath_scroll)).perform()
+
+    xpath = f"//ul[@id='pills-section-list']/li/a[text()='{tab_name}']"
+    WebDriverWait(page.driver(), 10).until(EC.element_to_be_clickable((By.XPATH, xpath)))
+    page.find_by_xpath(xpath).click()
+
     page.find_by_xpath(f"//ul[@id='pills-section-list']/li/a[text()='{tab_name}']").click()
 
     def wait_for_active_tab(*args):


### PR DESCRIPTION
- Wait for specialist providers to load before clicking the assign provider button - Specialist providers are only loaded after clicking on the assign tab on new cases, so I have added a polling wait to avoid a race condition of clicking the assign button before the providers have loaded.

- According to the TAP team the issue of the click being intercepted for the inner finances tab was caused by case bar being always fixed at the top of the page. On smaller viewports(resizing the browser) this causes the finances tab disappear behind the case bar which causes it to receive the clicks intended for the inner finances tab.
To remedy this issue, the TAP team have suggested that we set the window size to a fixed size. I have added a call to maximise the page before the start of all the tests

- Add an additional check if the finance inner tabs are clickable before clicking the inner tab - This is due to some inconsistencies of the tab click being intercepted by another element.

- Remove the following unused imports from means_test.py:
  - CLA_CASE_DETAILS_INNER_TAB
  - MINIMUM_SLEEP_SECONDS