### PR TITLE
Feature/lga 1865 login chs newly created user

### DIFF
--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -33,9 +33,16 @@ USERS = {
                                "login_url": f"{CLA_BACKEND_URL}/admin/login",
                                "user_type": "OPERATOR",
                                "application": "BACKEND"},
+    "FOX_ADMIN_NEW_USER": {"username": "elvis.presley",
+                           "password": "rockandroll",
+                           "login_url": f"{CLA_BACKEND_URL}/admin/login",
+                           "user_type": "OPERATOR",
+                           "application": "BACKEND"},
 }
-
-FOX_ADMIN_NEW_OPERATOR = "elvis.presley"
+# value_key is linked to FOX_ADMIN_NEW_USER
+FOX_ADMIN_NEW_OPERATOR = {"username": {"label": "Username:", "value_key": "username"},
+                          "password": {"label": "Password:", "value_key": "password"},
+                          "password_confirmation": {"label": "Password confirmation:", "value_key": "password"}}
 
 USER_HTML_TAGS = {
     "FRONTEND":

--- a/behave/features/constants.py
+++ b/behave/features/constants.py
@@ -40,7 +40,7 @@ USERS = {
                            "application": "BACKEND"},
 }
 # value_key is linked to FOX_ADMIN_NEW_USER
-FOX_ADMIN_NEW_OPERATOR = {"username": {"label": "Username:", "value_key": "username"},
+FOX_ADMIN_FORM_FIELDS = {"username": {"label": "Username:", "value_key": "username"},
                           "password": {"label": "Password:", "value_key": "password"},
                           "password_confirmation": {"label": "Password confirmation:", "value_key": "password"}}
 

--- a/behave/features/foxadmin_users.feature
+++ b/behave/features/foxadmin_users.feature
@@ -14,19 +14,16 @@ And I select save
 Then the users details are saved and I am taken back to the list of users
 And I select the link "Log out"
 
-#Journey P11 Child 2 Create an operator user (LGA-1864)
+#Journey P11 Child 2, Child 3 Create an operator user and login (LGA-1864, LGA-1865)
 @fox-create-user
 Scenario: Create an operator user
 Given I select the link "Operators"
 And I choose to "Add operator"
 And I am taken to the "Add operator" page located on "/admin/call_centre/operator/add/"
-And I <provide> the <details> to create a user
-        | details                    | provide           |
-        | Username:                  | elvis.presley     |
-        | Password:                  | rockandroll       |
-        | Password confirmation:     | rockandroll       |
+And I create a new operator user
 And I select 'Is active’
 And I choose to "save"
 Then the new operator user is created
 And I am taken to the list of operators page
 And I select the link "Log out"
+And that I am logged in as "FOX_ADMIN_NEW_USER"

--- a/behave/features/steps/foxadmin.py
+++ b/behave/features/steps/foxadmin.py
@@ -4,7 +4,7 @@ import datetime
 from selenium.webdriver.support.ui import WebDriverWait
 import os
 from features.constants import MINIMUM_WAIT_UNTIL_TIME, CLA_BACKEND_USER_TO_ASSIGN_STATUS_TO, \
-    CLA_BACKEND_USER_TO_ASSIGN_STATUS_TO_PK, FOX_ADMIN_NEW_OPERATOR, USERS
+    CLA_BACKEND_USER_TO_ASSIGN_STATUS_TO_PK, FOX_ADMIN_FORM_FIELDS, USERS
 from features.steps.common_steps import wait_until_page_is_loaded, assert_header_on_page
 
 
@@ -139,7 +139,7 @@ def step_impl(context, action):
 def step_impl(context):
     # Find the question by details
     # Find corresponding input and insert value from provide
-    new_user = FOX_ADMIN_NEW_OPERATOR
+    new_user = FOX_ADMIN_FORM_FIELDS
     for key in new_user.values():
         xpath = f".//label[text()='{key['label']}']/following-sibling::input"
         context.helperfunc.find_by_xpath(xpath).send_keys(USERS["FOX_ADMIN_NEW_USER"][key['value_key']])

--- a/behave/features/steps/foxadmin.py
+++ b/behave/features/steps/foxadmin.py
@@ -3,7 +3,8 @@ from selenium.webdriver.common.by import By
 import datetime
 from selenium.webdriver.support.ui import WebDriverWait
 import os
-from features.constants import MINIMUM_WAIT_UNTIL_TIME, CLA_BACKEND_USER_TO_ASSIGN_STATUS_TO, CLA_BACKEND_USER_TO_ASSIGN_STATUS_TO_PK, FOX_ADMIN_NEW_OPERATOR
+from features.constants import MINIMUM_WAIT_UNTIL_TIME, CLA_BACKEND_USER_TO_ASSIGN_STATUS_TO, \
+    CLA_BACKEND_USER_TO_ASSIGN_STATUS_TO_PK, FOX_ADMIN_NEW_OPERATOR, USERS
 from features.steps.common_steps import wait_until_page_is_loaded, assert_header_on_page
 
 
@@ -134,15 +135,14 @@ def step_impl(context, action):
     context.helperfunc.click_button(By.XPATH, xpath)
 
 
-@step(u'I <provide> the <details> to create a user')
+@step(u'I create a new operator user')
 def step_impl(context):
     # Find the question by details
     # Find corresponding input and insert value from provide
-    for row in context.table:
-        text = row['details']
-        value = row['provide']
-        xpath = f".//label[text()='{text}']/following-sibling::input"
-        context.helperfunc.find_by_xpath(xpath).send_keys(value)
+    new_user = FOX_ADMIN_NEW_OPERATOR
+    for key in new_user.values():
+        xpath = f".//label[text()='{key['label']}']/following-sibling::input"
+        context.helperfunc.find_by_xpath(xpath).send_keys(USERS["FOX_ADMIN_NEW_USER"][key['value_key']])
 
 
 @step(u'I select \'Is active’')
@@ -169,9 +169,9 @@ def step_impl(context):
     context.execute_steps('''
     Then I am taken to the "Select operator to change" page located on "/admin/call_centre/operator/"''')
     # the user just created exists - look for the created user in the table
-    xpath = f".//table[@id='result_list']/tbody/tr[th/a[text()='{FOX_ADMIN_NEW_OPERATOR}']]"
+    xpath = f".//table[@id='result_list']/tbody/tr[th/a[text()='{USERS['FOX_ADMIN_NEW_USER']['username']}']]"
     # .//table[@id='result_list']/tbody/tr[th/a[text()='elvis.presley']]
-    assert context.helperfunc.find_by_xpath(xpath) is not None, f"cannot find row with user {FOX_ADMIN_NEW_OPERATOR}"
+    assert context.helperfunc.find_by_xpath(xpath) is not None, f"cannot find row with user {USERS['FOX_ADMIN_NEW_USER']['username']}"
     # now check that it is active but not a manager or a superuser
     image_path_yes = "/static/admin/img/icon-yes.gif"
     image_path_no = "/static/admin/img/icon-no.gif"


### PR DESCRIPTION
- Refactored step where scenario outline was used for creating a new test operator. 
- Updated step I am taken to the list of operators page to work with new dictionaries created for login and creating new user.
- Add step in feature file to login into "FOX_ADMIN_NEW_USER"