### PR TITLE
LGA 2283 Retry test failures

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -1,5 +1,6 @@
 import os
 import time
+from behave.contrib.scenario_autoretry import patch_scenario_with_autoretry
 from behave.log_capture import capture
 from helper.constants import BROWSER, ARTIFACTS_DIRECTORY, DOWNLOAD_DIRECTORY
 from helper.helper_web import get_browser
@@ -14,6 +15,11 @@ def before_all(context):
     # dir for report fox_admin_downloads
     context.download_dir = DOWNLOAD_DIRECTORY
     helper_func.maximize()
+
+
+def before_feature(feature):
+    for scenario in feature.scenarios:
+        patch_scenario_with_autoretry(scenario, max_attempts=3)
 
 
 @capture

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -17,7 +17,7 @@ def before_all(context):
     helper_func.maximize()
 
 
-def before_feature(feature):
+def before_feature(context, feature):
     for scenario in feature.scenarios:
         patch_scenario_with_autoretry(scenario, max_attempts=3)
 


### PR DESCRIPTION
Added a before_feature hook which patches the scenarios in each feature with an autoretry.

This will at a maximum retry 3 times.

This is to deal with the flakey test issue that we have mostly occuring on circleci, generally around how long something takes to load.