### PR TITLE
Feature/LGA-2382: Apply filter on search

### DIFF
--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -22,10 +22,10 @@ Feature: FALA end to end tests
     Given I provide the "<location>" details
     When I select the 'search' button on the FALA homepage
     Then I am taken to the page corresponding to "<location>" result
-    When I "<filter>" by category on the result page
+    When I browse through the filter categories and select "<filter_label>"
     And I select the 'Apply filter' button
-    Then the result number and list has been updated to reflect the applied filter
+    Then the result page containing "<location>" is updated to apply the filter "<filter_label>"
     Examples:
-      | location | filter |
-      | SW1H9AJ  | Crime  |
-      | London   | Crime  |
+      | location | filter_label |
+      | SW1H9AJ  | Crime        |
+      | London   | Housing      |

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -13,7 +13,7 @@ Feature: FALA end to end tests
     Then I am taken to the page corresponding to "<location>" result
     Examples:
       | location |
-      | SW1H9AJ |
+      | SW1H9AJ  |
       | London   |
 
 
@@ -22,10 +22,10 @@ Feature: FALA end to end tests
     Given I provide the "<location>" details
     When I select the 'search' button on the FALA homepage
     Then I am taken to the page corresponding to "<location>" result
-    When I filter by the category 'Crime' on the result page
+    When I "<filter>" by category on the result page
     And I select the 'Apply filter' button
-    Then my result number and list has been updated to reflect the applied filter
+    Then the result number and list has been updated to reflect the applied filter
     Examples:
-      | location |
-      | SW1H9AJ |
-      | London   |
+      | location | filter |
+      | SW1H9AJ  | Crime  |
+      | London   | Crime  |

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -15,3 +15,17 @@ Feature: FALA end to end tests
       | location |
       | SW1H9AJ |
       | London   |
+
+
+  @fala-apply-filter-after-search
+  Scenario Outline: Applying filters on the result page provide a new result list of legal advisers
+    Given I provide the "<location>" details
+    When I select the 'search' button on the FALA homepage
+    Then I am taken to the page corresponding to "<location>" result
+    When I filter by the category 'Crime' on the result page
+    And I select the 'Apply filter' button
+    Then my result number and list has been updated to reflect the applied filter
+    Examples:
+      | location |
+      | SW1H9AJ |
+      | London   |

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -38,7 +38,44 @@ def step_impl_result_page(context, location):
     result_number_paragraph = context.helperfunc.find_by_xpath(
         '//p[@class="govuk-body"]'
     )
-
     assert current_path, f"""{CLA_FALA_URL}/?postcode={location}+&name=&search="""
     assert title_xpath, f"{FALA_HEADER}"
     assert result_container_xpath, result_number_paragraph is not None
+
+
+@step('I "{filter}" by category on the result page')
+def step_impl_click_checkbox_filter(context):
+    # click filter checkbox
+    for row in context.table:
+        label = row["filter"]
+        checkbox_xpath = context.helperfunc.find_by_xpath(
+            f"//fieldset/div/div/label[contains(text(), '{label}')]"
+        )
+        checkbox_xpath.click()
+
+
+@step("I select the 'Apply filter' button")
+def step_impl_apply_filter(context):
+    # click apply filter
+    apply_filter_button = context.helperfunc.find_by_name("filter")
+    assert apply_filter_button is not None
+    apply_filter_button.click()
+
+
+@step("the result number and list has been updated to reflect the applied filter")
+def step_impl_update_result_page(context, location, filter_value):
+    # update result page
+    current_path = context.helperfunc.get_current_path()
+    title_xpath = context.helperfunc.find_by_xpath("//html/body/div/main/div/div/h1")
+    result_container_xpath = context.helperfunc.find_by_xpath(
+        '//div[@class="search-results-container"]'
+    )
+    updated_result_number_paragraph = context.helperfunc.find_by_xpath(
+        '//p[@class="govuk-body"]'
+    )
+    assert (
+        current_path
+    ), f"""{CLA_FALA_URL}/?postcode={location}&name=&categories={filter_value}&filter="""
+    assert title_xpath, f"{FALA_HEADER}"
+    assert result_container_xpath is not None
+    assert updated_result_number_paragraph is not None

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -43,28 +43,31 @@ def step_impl_result_page(context, location):
     assert result_container_xpath, result_number_paragraph is not None
 
 
-@step('I "{filter}" by category on the result page')
-def step_impl_click_checkbox_filter(context):
-    # click filter checkbox
-    for row in context.table:
-        label = row["filter"]
-        checkbox_xpath = context.helperfunc.find_by_xpath(
-            f"//fieldset/div/div/label[contains(text(), '{label}')]"
-        )
-        checkbox_xpath.click()
+@step('I browse through the filter categories and select "{filter_label}"')
+def step_impl_click_checkbox_filter(context, filter_label):
+    find_label_in_labels_list = context.helperfunc.find_many_by_xpath(
+        f"//fieldset/div/div/label[contains(text(), '{filter_label}')]"
+    )
+    checkbox_list = context.helperfunc.find_many_by_xpath("//fieldset/div/div/input")
+    for checkbox in checkbox_list:
+        if find_label_in_labels_list == filter_label:
+            checkbox.click()
+            assert checkbox is not None
+
+    assert find_label_in_labels_list, f"{filter_label}"
 
 
 @step("I select the 'Apply filter' button")
 def step_impl_apply_filter(context):
-    # click apply filter
     apply_filter_button = context.helperfunc.find_by_name("filter")
     assert apply_filter_button is not None
     apply_filter_button.click()
 
 
-@step("the result number and list has been updated to reflect the applied filter")
-def step_impl_update_result_page(context, location, filter_value):
-    # update result page
+@step(
+    'the result page containing "{location}" is updated to apply the filter "{filter_label}"'
+)
+def step_impl_update_result_page(context, location, filter_label):
     current_path = context.helperfunc.get_current_path()
     title_xpath = context.helperfunc.find_by_xpath("//html/body/div/main/div/div/h1")
     result_container_xpath = context.helperfunc.find_by_xpath(
@@ -75,7 +78,7 @@ def step_impl_update_result_page(context, location, filter_value):
     )
     assert (
         current_path
-    ), f"""{CLA_FALA_URL}/?postcode={location}&name=&categories={filter_value}&filter="""
+    ), f"""{CLA_FALA_URL}/?postcode={location}&name=&categories={filter_label}&filter="""
     assert title_xpath, f"{FALA_HEADER}"
     assert result_container_xpath is not None
     assert updated_result_number_paragraph is not None


### PR DESCRIPTION
## What does this pull request do?
This is an end to end test to verify that FALA is working accordingly. It checks if:

1. the user is on the homepage
2. the input field for postcode/city is filled with the user's text
3. the search button send the request
4. the result page appears and displays the search result
5. a filter can be selected
6. the filter can be applied
7. the filter create a new request with the latest information