### PR TITLE
Feature/LGA-2391: FALA e2e tests - search with no results

### DIFF
--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -29,3 +29,11 @@ Feature: FALA end to end tests
       | location | filter_label |
       | SW1H9AJ  | Crime        |
       | London   | Housing      |
+
+
+  @fala-search-no-results
+  Scenario: I search for a town that does not have any solicitors and fails
+  Given I am on the Find a legal aid adviser homepage
+  And I provide the "Heswall" details
+  When I select the 'search' button on the FALA homepage
+  Then the page shows an error

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -82,3 +82,10 @@ def step_impl_update_result_page(context, location, filter_label):
     assert title_xpath, f"{FALA_HEADER}"
     assert result_container_xpath is not None
     assert updated_result_number_paragraph is not None
+
+
+@step("the page shows an error")
+def step_impl_error_shown_on_page(context):
+    alert = context.helperfunc.find_by_css_selector(".alert-message")
+    assert alert is not None
+    assert alert.text, "No results"


### PR DESCRIPTION
## What does this pull request do?
This PR adds an end-to-end test for FALA. 

It covers the "I search for a town that does not have an solicitors and fails" scenario:

**Given** I am on the Find a legal aid adviser homepage
**And** I provide location details via “Falmouth“ 
**Then** the page shows an error message

