### PR TITLE
LGA-2350 correcting if statement to new boolean value. If a11y_runnin…

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -37,7 +37,7 @@ def before_feature(context, feature):
 
 @capture
 def after_scenario(context, scenario):
-    if context.a11y_running:
+    if not context.a11y_running:
         logging.error("ACCESSIBILITY ISSUES FOUND, CHECK ARTIFACTS FOR INFORMATION")
     if scenario.status == "failed":
         scenario_error_dir = os.path.join(context.artifacts_dir, "feature_errors")

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -22,7 +22,7 @@ def before_all(context):
     # dir for report fox_admin_downloads
     context.download_dir = DOWNLOAD_DIRECTORY
     # Boolean for axe finding a11y issues or not
-    context.a11y_running = False
+    context.a11y_approved = True
     # Boolean that a11y environment variables are set
     a11y_arg = context.config.userdata.get("a11y", "false").lower() == "true"
     # Set userdata a11y to be boolean value and not a String
@@ -37,7 +37,7 @@ def before_feature(context, feature):
 
 @capture
 def after_scenario(context, scenario):
-    if not context.a11y_running:
+    if not context.a11y_approved:
         logging.error("ACCESSIBILITY ISSUES FOUND, CHECK ARTIFACTS FOR INFORMATION")
     if scenario.status == "failed":
         scenario_error_dir = os.path.join(context.artifacts_dir, "feature_errors")
@@ -59,4 +59,5 @@ def after_all(context):
 def after_step(context, step):
     # command to run: behave -D a11y=true -t @a11y-check
     if context.config.userdata["a11y"] and get_tag(context.tags, A11Y_TAG):
-        context.a11y_running = check_accessibility(context)
+        # Returns False if a11y issues are found
+        context.a11y_approved = check_accessibility(context)


### PR DESCRIPTION
## What is this PR for?

This PR is add axe-selenium-python to our existing end to end tests. Tests that have tags @a11y-check above their scenario will be called when a custom command `behave -D a11y=true -t @a11y-check` is called. 

Axe is only called unless custom command is used, Axe will not be called if you just run all tests by default. This PR has been set up to take docker environment variables to allow boolean commands if it's in a project pipeline that we wish to have end to end tests to run, e.g. `cla_public`.

## What to check

- Does the tests with the command run correctly?
- Does it Axe create a JSON report?
- Is the environment set up correctly to allow custom commands to be passed?
- Is the code efficient?

## Notes

- A PR for `cla_public` exists to pass boolean environment variables.  