### PR TITLE
LGA-2389 add filtering on homepage test and refactor test steps

### DIFF
--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -25,7 +25,7 @@ Feature: FALA end to end tests
     When I browse through the filter categories and select "<filter_label>"
     And I select the 'Apply filter' button
     Then the result page containing "<location>" is updated to apply the filter "<filter_label>"
-    And 10 result is visible on the results page
+    And there are less results visible on the results page
     Examples:
       | location | filter_label |
       | SW1H 9AJ | crm          |

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -13,7 +13,7 @@ Feature: FALA end to end tests
     Then I am taken to the page corresponding to "<location>" result
     Examples:
       | location |
-      | SW1H9AJ  |
+      | SW1H 9AJ |
       | London   |
 
 
@@ -25,9 +25,10 @@ Feature: FALA end to end tests
     When I browse through the filter categories and select "<filter_label>"
     And I select the 'Apply filter' button
     Then the result page containing "<location>" is updated to apply the filter "<filter_label>"
+    And 10 result is visible on the results page
     Examples:
       | location | filter_label |
-      | SW1H9AJ  | crm          |
+      | SW1H 9AJ | crm          |
       | London   | hou          |
 
 
@@ -59,3 +60,16 @@ Feature: FALA end to end tests
       | cy              | Welsh         | Dewch                  |
       | gd              | Scots Gaelic  | Lorg                   |
 
+
+  @fala-filtering-homepage
+  Scenario Outline: Applying filters on the homepage, filters correctly
+    Given I collect the resulting number for a generic "<location>" search
+    When I am on the Find a legal aid adviser homepage
+    And I provide the "<location>" details
+    And I browse through the filter categories and select "<filter_label>"
+    And I select the 'Apply filter' button
+    Then the result page containing "<location>" is updated to apply the filter "<filter_label>"
+    And there are less results visible on the results page
+    Examples:
+      | location | filter_label |
+      | London   | edu          |

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -62,7 +62,7 @@ Feature: FALA end to end tests
 
 
   @fala-filtering-homepage
-  Scenario Outline: Applying filters on the homepage, filters correctly
+  Scenario Outline: Applying filters specifically on the homepage, filters correctly
     Given I collect the resulting number for a generic "<location>" search
     When I am on the Find a legal aid adviser homepage
     And I provide the "<location>" details

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -72,7 +72,7 @@ def step_impl_result_page_with_location_only(context, location):
     )
     expected_title = FALA_HEADER
 
-    assert_result_page(context, expected_url, expected_title, True)
+    assert_result_page(context, expected_url, expected_title, expected_results=True)
 
 
 @step('I browse through the filter categories and select "{filter_label}"')

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -131,7 +131,6 @@ def step_impl_count_results_visible_on_results_page(context, count):
     assert list_count == count, f"actual count is {list_count}"
 
 
-<<<<<<< HEAD
 @step('I select the language "{language}" with value "{code_indicator}"')
 def step_impl_select_language(context, language, code_indicator):
     def select_text(*args):
@@ -170,6 +169,7 @@ def step_impl_translated(context, code_indicator, title_text_starts_with):
 
     assert updated_page == f"{code_indicator}"
     assert updated_title_gui.startswith(f"{title_text_starts_with}")
+
 
 @step("There are less results visible on the results page")
 def step_impl_fewer_results_returned(context):

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -5,6 +5,35 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import StaleElementReferenceException
 
 
+def assert_result_page(context, expected_url, expected_title, expected_results=False):
+    current_url = context.helperfunc.driver().current_url
+    title_xpath = context.helperfunc.find_by_xpath(
+        "//html/body/div/main/div/div/h1"
+    ).text.replace("\n", " ")
+    result_container_xpath = context.helperfunc.find_by_xpath(
+        '//div[@class="search-results-container"]'
+    )
+    result_number_paragraph = context.helperfunc.find_by_xpath(
+        '//section/p[@class="govuk-body"]'
+    )
+
+    assert (
+        current_url == expected_url
+    ), f"URL does not match expected value {expected_url}"
+    assert (
+        title_xpath == expected_title
+    ), f"Page title does not match expected value {expected_title}"
+    assert (
+        result_container_xpath is not None
+    ), "Could not find search results container element"
+    assert (
+        result_number_paragraph is not None
+    ), "Could not find result number paragraph element"
+
+    if expected_results:
+        context.results = int(result_number_paragraph.text.split()[0])
+
+
 @step("I am on the Find a legal aid adviser homepage")
 def step_impl_homepage(context):
     homepage_url = f"{CLA_FALA_URL}"
@@ -19,16 +48,14 @@ def step_impl_homepage(context):
 def step_impl_input_location(context, location):
     input_id = context.helperfunc.find_by_id("id_postcode")
     input_id.send_keys(location)
-    input_value = input_id.get_attribute("value")
-    assert input_value == location
+    assert input_id.get_attribute("value") == location
 
 
 @step('I provide an organisation name "{organisation}"')
 def step_impl_input_organisation(context, organisation):
     input_id = context.helperfunc.find_by_id("id_name")
     input_id.send_keys(organisation)
-    input_value = input_id.get_attribute("value")
-    assert input_value == organisation
+    assert input_id.get_attribute("value") == organisation
 
 
 @step("I select the 'search' button on the FALA homepage")
@@ -39,24 +66,13 @@ def step_impl_click_search(context):
 
 
 @step('I am taken to the page corresponding to "{location}" result')
-def step_impl_result_page(context, location):
-    current_url = context.helperfunc.driver().current_url
-    title_xpath = context.helperfunc.find_by_xpath(
-        "//html/body/div/main/div/div/h1"
-    ).text.replace("\n", " ")
-    result_container_xpath = context.helperfunc.find_by_xpath(
-        '//div[@class="search-results-container"]'
+def step_impl_result_page_with_location_only(context, location):
+    expected_url = (
+        f"{CLA_FALA_URL}/?postcode={location.replace(' ', '+')}&name=&search="
     )
-    result_number_paragraph = context.helperfunc.find_by_xpath(
-        '//p[@class="govuk-body"]'
-    )
-    location_url_string = location.replace(" ", "+")
-    expected_url = f"""{CLA_FALA_URL}/?postcode={location_url_string}&name=&search="""
+    expected_title = FALA_HEADER
 
-    assert current_url == expected_url
-    assert title_xpath == f"{FALA_HEADER}"
-    assert result_container_xpath is not None
-    assert result_number_paragraph is not None
+    assert_result_page(context, expected_url, expected_title, True)
 
 
 @step('I browse through the filter categories and select "{filter_label}"')
@@ -78,24 +94,12 @@ def step_impl_apply_filter(context):
 @step(
     'the result page containing "{location}" is updated to apply the filter "{filter_label}"'
 )
-def step_impl_update_result_page(context, location, filter_label):
-    current_url = context.helperfunc.driver().current_url
-    title_xpath = context.helperfunc.find_by_xpath(
-        "//html/body/div/main/div/div/h1"
-    ).text.replace("\n", " ")
-    result_container_xpath = context.helperfunc.find_by_xpath(
-        '//div[@class="search-results-container"]'
-    )
-    updated_result_number_paragraph = context.helperfunc.find_by_xpath(
-        '//p[@class="govuk-body"]'
-    )
+def step_impl_result_page_with_location_filter(context, location, filter_label):
     location_url_string = location.replace(" ", "+")
-    expected_url = f"""{CLA_FALA_URL}/?postcode={location_url_string}&name=&categories={filter_label}&filter="""
+    expected_url = f"{CLA_FALA_URL}/?postcode={location_url_string}&name=&categories={filter_label}&filter="
+    expected_title = FALA_HEADER
 
-    assert current_url == expected_url
-    assert title_xpath == f"{FALA_HEADER}"
-    assert result_container_xpath is not None
-    assert updated_result_number_paragraph is not None
+    assert_result_page(context, expected_url, expected_title)
 
 
 @step("the page shows an error")
@@ -109,25 +113,13 @@ def step_impl_error_shown_on_page(context):
 @step(
     'I am taken to the page corresponding to the "{location}" "{organisation}" search result'
 )
-def step_impl_result_page_with_multi_params(context, location, organisation):
-    result_number_paragraph = context.helperfunc.find_by_xpath(
-        '//p[@class="govuk-body"]'
-    )
-    current_url = context.helperfunc.driver().current_url
-    title_xpath = context.helperfunc.find_by_xpath(
-        "//html/body/div/main/div/div/h1"
-    ).text.replace("\n", " ")
-    result_container_xpath = context.helperfunc.find_by_xpath(
-        '//div[@class="search-results-container"]'
-    )
+def step_impl_result_page_with_location_organisation(context, location, organisation):
     organisation_url_string = organisation.replace(" ", "+")
     location_url_string = location.replace(" ", "+")
-    expected_url = f"""{CLA_FALA_URL}/?postcode={location_url_string}&name={organisation_url_string}&search="""
+    expected_url = f"{CLA_FALA_URL}/?postcode={location_url_string}&name={organisation_url_string}&search="
+    expected_title = FALA_HEADER
 
-    assert current_url == expected_url
-    assert title_xpath == f"{FALA_HEADER}"
-    assert result_container_xpath is not None
-    assert result_number_paragraph is not None
+    assert_result_page(context, expected_url, expected_title)
 
 
 @step("{count:d} result is visible on the results page")
@@ -139,6 +131,7 @@ def step_impl_count_results_visible_on_results_page(context, count):
     assert list_count == count, f"actual count is {list_count}"
 
 
+<<<<<<< HEAD
 @step('I select the language "{language}" with value "{code_indicator}"')
 def step_impl_select_language(context, language, code_indicator):
     def select_text(*args):
@@ -177,3 +170,21 @@ def step_impl_translated(context, code_indicator, title_text_starts_with):
 
     assert updated_page == f"{code_indicator}"
     assert updated_title_gui.startswith(f"{title_text_starts_with}")
+
+@step("There are less results visible on the results page")
+def step_impl_fewer_results_returned(context):
+    total_results = context.helperfunc.find_by_xpath(
+        '//section/p[@class="govuk-body"]'
+    ).text.split()[0]
+    assert int(total_results) < context.results
+
+
+@step('I collect the resulting number for a generic "{location}" search')
+def step_impl_resulting_generic_search(context, location):
+    context.execute_steps(
+        f"""
+        Given I provide the "{location}" details
+        And I select the 'search' button on the FALA homepage
+        And I am taken to the page corresponding to "{location}" result
+    """
+    )


### PR DESCRIPTION
- Covers the applying filters on the homepage search, filters correctly scenario:

**Given** I collect the resulting number for a generic search
**And** I provide location details via “postcode“
**And** I filter by the category “Crime“
**When** I select the Search button
**Then** I am taken to the search results page
**Then** my result number has been updated to reflect the applied filter.

- Refactored the three functions used for search results page (placed common logic into assert_result_page function)
- Added an additional step to a previous test to check that results are shown when applying a filter (discussed with Patrick)