### PR TITLE
LGA-2414/fix CLA FALA end-to-end test failing on cla_public

### DIFF
--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -101,6 +101,7 @@ def after_scenario(context, scenario):
             + ".png",
         )
         context.helperfunc.take_screenshot(scenario_file_path)
+    context.helperfunc.delete_cookies()
 
 
 def after_all(context):

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -18,10 +18,10 @@ def assert_result_page(context, expected_url, expected_title, expected_results=F
 
     assert (
         current_url == expected_url
-    ), f"URL does not match expected value {expected_url}"
+    ), f" actual URL {current_url} does not match expected value {expected_url}"
     assert (
         title_xpath == expected_title
-    ), f"Page title does not match expected value {expected_title}"
+    ), f"Page title {title_xpath} does not match expected value {expected_title}"
     assert (
         result_container_xpath is not None
     ), "Could not find search results container element"

--- a/behave/helper/helper_base.py
+++ b/behave/helper/helper_base.py
@@ -25,6 +25,9 @@ class HelperFunc(object):
     def driver(self):
         return self._driver
 
+    def delete_cookies(self):
+        return self._driver.delete_all_cookies()
+
     def open(self, url):
         self._driver.get(url)
 


### PR DESCRIPTION
## What does this pull request do?

The FALA end-to-end test (@fala-apply-filter-on-homepage) that run right after the change language tests (@fala-dom-translation) were failing only on cla_public. The error was that the page was translated to Scot Gaelic in the first test and did not revert to English in the next test.

Further investigation found that the time.sleep() function in our check_accessibility function was causing this only in our cla_public pipeline.

This work:
- adds a delete_cookies helper function
- uses the delete_cookies function after each test scenario
- updates some of the error logging message so we can see what the actual values are if the test fails again in future

## Any other changes that would benefit highlighting?

Tried running all tests where we log out at the end (but commented out the log out step) in one run and these tests still passed. 

I believe the [runner operation](https://behave.readthedocs.io/en/stable/api.html?highlight=after_scenario#runner-operation) section of the documentation suggests that the patch with autoretry function should run the `after_scenario` function between retries. We currently call `patch_scenario_with_autoretry()` in `before_feature`. Will need to monitor this to confirm this. 

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"