### PR TITLE
Feature/lga 2411 format a11y json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,6 @@ node_modules/
 
 .sass-cache/
 behave/data/*
+behave/fox_admin_downloads
 # exception to the rule
 !behave/data/.gitkeep

--- a/behave/README.md
+++ b/behave/README.md
@@ -102,6 +102,21 @@ chromedriver # take note of the port listed. Will stay running in the foreground
 ./run_test_local_chrome_driver.sh -t "createuser"
 ```
 
+### Run Accessibility tests
+[axe-selenium-python](https://pypi.org/project/axe-selenium-python/) 
+[core-documentation](https://www.deque.com/axe/core-documentation/api-documentation) 
+
+To turn on accessibility checks, set the 'define' value. 
+`behave -D a11y=true`
+
+To call all accessibility tests with `@a11y-check` tags
+`behave -D a11y=true -t @a11y-check`
+
+Finding the a11y.json report
+`behave/data/a11y_reports/a11y.json`
+
+Reports are generated at the end of a single test or whole run test run.
+
 ## Lint and pre-commit hooks
 
 To lint with Black and flake8, install pre-commit hooks:

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -14,6 +14,7 @@ from helper.constants import (
 
 from helper.helper_web import get_browser
 from features.steps.common_steps import check_accessibility, make_dir, get_tag
+import json
 
 
 def before_all(context):
@@ -104,7 +105,10 @@ def after_scenario(context, scenario):
 
 
 def after_all(context):
+    with json.loads(f"{context.a11y_reports_dir}/a11y.json") as f:
+        json.dump(f, f)
     context.helperfunc.close()
+
 
 
 def after_step(context, step):

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -14,7 +14,6 @@ from helper.constants import (
 
 from helper.helper_web import get_browser
 from features.steps.common_steps import check_accessibility, make_dir, get_tag
-import json
 
 
 def before_all(context):
@@ -108,9 +107,8 @@ def after_all(context):
     context.helperfunc.close()
 
 
-
 def after_step(context, step):
     # command to run: behave -D a11y=true -t @a11y-check
     if context.config.userdata["a11y"] and get_tag(context.tags, A11Y_TAG):
         # Returns False if a11y issues are found
-        context.a11y_approved = check_accessibility(context)
+        context.a11y_approved = check_accessibility(context, step.name)

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -105,8 +105,6 @@ def after_scenario(context, scenario):
 
 
 def after_all(context):
-    with json.loads(f"{context.a11y_reports_dir}/a11y.json") as f:
-        json.dump(f, f)
     context.helperfunc.close()
 
 

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -110,13 +110,13 @@ def after_scenario(context, scenario):
 
 
 def after_all(context):
-    if context.config.userdata["a11y"] and get_tag(context.tags, A11Y_TAG):
+    if context.config.userdata["a11y"]:
         filter_accessibility_report(context)
     context.helperfunc.close()
 
 
 def after_step(context, step):
-    # command to run: behave -D a11y=true -k -s --no-capture -t @fala
+    # command to run: behave -D a11y=true -k -s --no-capture -t @a11y-check
     if context.config.userdata["a11y"] and get_tag(context.tags, A11Y_TAG):
         # Returns False if a11y issues are found
         context.a11y_approved = check_accessibility(context, step.name)

--- a/behave/features/environment.py
+++ b/behave/features/environment.py
@@ -2,7 +2,6 @@ import os
 import time
 import logging
 import subprocess
-
 from behave.contrib.scenario_autoretry import patch_scenario_with_autoretry
 from behave.log_capture import capture
 
@@ -116,7 +115,7 @@ def after_all(context):
 
 
 def after_step(context, step):
-    # command to run: behave -D a11y=true -k -s --no-capture -t @a11y-check
+    # command to run: behave -D a11y=true -t @a11y-check
     if context.config.userdata["a11y"] and get_tag(context.tags, A11Y_TAG):
         # Returns False if a11y issues are found
         context.a11y_approved = check_accessibility(context, step.name)

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -300,7 +300,20 @@ def check_accessibility(context):
     time.sleep(0.6)
     axe = Axe(context.helperfunc.driver())
     axe.inject()
-    results = axe.run("resultTypes", ["violations", "incomplete"])
+    results = axe.run(
+        options={
+            "runOnly": {
+                "type": "rule",
+                "values": [
+                    "area-alt",
+                    "aria-allowed-attr",
+                    "color-contrast",
+                    "valid-lang",
+                ],
+            },
+            "resultTypes": ["violations", "incomplete"],
+        }
+    )
     if len(results["violations"]) > 0:
         axe.write_results(results, f"{context.a11y_reports_dir}/a11y.json")
     return len(results["violations"]) == 0

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -324,17 +324,17 @@ def check_accessibility(context, step_name):
 
 def filter_accessibility_report(context):
     with open(f"{context.a11y_reports_dir}/a11y.json", "r") as f:
-        data = json.load(f)
+        reported_issues = json.load(f)
 
-    results_to_copy = []
-    for error in data:
-        violations = error["violations"]
+    filtered_issues = []
+    for step_error in reported_issues:
+        violations = step_error["violations"]
         # Check if the current violation is already in results_to_copy
-        if not any(violations == issue["violations"] for issue in results_to_copy):
-            results_to_copy.append(error)
+        if not any(violations == issue["violations"] for issue in filtered_issues):
+            filtered_issues.append(step_error)
 
     with open(f"{context.a11y_reports_dir}/a11y_filtered.json", "x") as f:
         axe = Axe(context.helperfunc.driver())
         axe.write_results(
-            results_to_copy, f"{context.a11y_reports_dir}/a11y_filtered.json"
+            filtered_issues, f"{context.a11y_reports_dir}/a11y_filtered.json"
         )

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -13,8 +13,7 @@ from helper.constants import (
 from selenium.webdriver.common.by import By
 from axe_selenium_python import Axe
 import json
-from json2html import *
-import random
+
 
 def remove_prefix(text, prefix):
     return text[len(prefix) :] if text.startswith(prefix) else text
@@ -303,15 +302,17 @@ def check_accessibility(context):
     axe = Axe(context.helperfunc.driver())
     axe.inject()
     results = axe.run()
-    y = random.randrange(1,100000)
     if len(results["violations"]) > 0:
-        result_format = {str(y): dict(
+        result_format = [dict(
             url=context.helperfunc.get_url(), violations=results["violations"], incomplete=results["incomplete"]
-        )}
+        )]
 
-        with open(f"{context.a11y_reports_dir}/a11y.json", 'a') as f:
-            json.dump(result_format, f, indent=4)
-            f.write(',\n')
+        try:
+            f = open(f"{context.a11y_reports_dir}/a11y.json", 'r')
+            result_format = json.load(f) + result_format
+            axe.write_results(result_format, f"{context.a11y_reports_dir}/a11y.json")
             f.close()
+        except FileNotFoundError:
+            axe.write_results(result_format, f"{context.a11y_reports_dir}/a11y.json")
 
     return len(results["violations"]) == 0

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -302,11 +302,11 @@ def check_accessibility(context):
     axe.inject()
     results = axe.run()
     if len(results["violations"]) > 0:
-        # TODO: Python dictionary with key of violations
-        # Append results violations to Python key
+        result_format = dict(
+            violations=results["violations"], incomplete=results["incomplete"]
+        )
         axe.write_results(
-            results["violations"] + results["incomplete"],
+            result_format,
             f"{context.a11y_reports_dir}/a11y.json",
         )
-        # axe.report(results["violations"])
     return len(results["violations"]) == 0

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -12,7 +12,9 @@ from helper.constants import (
 )
 from selenium.webdriver.common.by import By
 from axe_selenium_python import Axe
-
+import json
+from json2html import *
+import random
 
 def remove_prefix(text, prefix):
     return text[len(prefix) :] if text.startswith(prefix) else text
@@ -301,12 +303,15 @@ def check_accessibility(context):
     axe = Axe(context.helperfunc.driver())
     axe.inject()
     results = axe.run()
+    y = random.randrange(1,100000)
     if len(results["violations"]) > 0:
-        result_format = dict(
-            violations=results["violations"], incomplete=results["incomplete"]
-        )
-        axe.write_results(
-            result_format,
-            f"{context.a11y_reports_dir}/a11y.json",
-        )
+        result_format = {str(y): dict(
+            url=context.helperfunc.get_url(), violations=results["violations"], incomplete=results["incomplete"]
+        )}
+
+        with open(f"{context.a11y_reports_dir}/a11y.json", 'a') as f:
+            json.dump(result_format, f, indent=4)
+            f.write(',\n')
+            f.close()
+
     return len(results["violations"]) == 0

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -300,7 +300,7 @@ def check_accessibility(context):
     time.sleep(0.6)
     axe = Axe(context.helperfunc.driver())
     axe.inject()
-    results = axe.run()
+    results = axe.run("resultTypes", ["violations", "incomplete"])
     if len(results["violations"]) > 0:
         axe.write_results(results, f"{context.a11y_reports_dir}/a11y.json")
     return len(results["violations"]) == 0

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -1,6 +1,7 @@
 import re
 import time
 import os
+import json
 from behave import step
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.wait import WebDriverWait
@@ -12,7 +13,6 @@ from helper.constants import (
 )
 from selenium.webdriver.common.by import By
 from axe_selenium_python import Axe
-import json
 
 
 def remove_prefix(text, prefix):
@@ -295,7 +295,7 @@ def make_dir(dir):
         os.makedirs(dir)
 
 
-def check_accessibility(context):
+def check_accessibility(context, step_name):
     # Sleep prevents Axe exceptions.
     # If no logs for Axe, Axe is called too fast when trying to inject javascript.
     time.sleep(0.6)
@@ -303,12 +303,16 @@ def check_accessibility(context):
     axe.inject()
     results = axe.run()
     if len(results["violations"]) > 0:
-        result_format = [dict(
-            url=context.helperfunc.get_url(), violations=results["violations"], incomplete=results["incomplete"]
-        )]
+        result_format = [
+            dict(
+                step=step_name,
+                url=context.helperfunc.get_url(),
+                violations=results["violations"],
+            )
+        ]
 
         try:
-            f = open(f"{context.a11y_reports_dir}/a11y.json", 'r')
+            f = open(f"{context.a11y_reports_dir}/a11y.json", "r")
             result_format = json.load(f) + result_format
             axe.write_results(result_format, f"{context.a11y_reports_dir}/a11y.json")
             f.close()

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -323,8 +323,8 @@ def check_accessibility(context, step_name):
 
 
 def filter_accessibility_report(context):
-    f = open(f"{context.a11y_reports_dir}/a11y.json", "r")
-    data = json.load(f)
+    with open(f"{context.a11y_reports_dir}/a11y.json", "r") as f:
+        data = json.load(f)
 
     results_to_copy = []
     for error in data:
@@ -333,7 +333,8 @@ def filter_accessibility_report(context):
         if not any(violations == issue["violations"] for issue in results_to_copy):
             results_to_copy.append(error)
 
-    f = open(f"{context.a11y_reports_dir}/a11y_filtered.json", "x")
-    axe = Axe(context.helperfunc.driver())
-    axe.write_results(results_to_copy, f"{context.a11y_reports_dir}/a11y_filtered.json")
-    f.close()
+    with open(f"{context.a11y_reports_dir}/a11y_filtered.json", "x") as f:
+        axe = Axe(context.helperfunc.driver())
+        axe.write_results(
+            results_to_copy, f"{context.a11y_reports_dir}/a11y_filtered.json"
+        )

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -320,3 +320,21 @@ def check_accessibility(context, step_name):
             axe.write_results(result_format, f"{context.a11y_reports_dir}/a11y.json")
 
     return len(results["violations"]) == 0
+
+
+def filter_accessibility_report(context):
+    with open(f"{context.a11y_reports_dir}/a11y.json", "r") as f:
+        data = json.load(f)
+
+    results_to_copy = []
+    for error in data:
+        violations = error["violations"]
+        # Check if the current violation is already in results_to_copy
+        if not any(violations == issue["violations"] for issue in results_to_copy):
+            results_to_copy.append(error)
+
+    with open(f"{context.a11y_reports_dir}/a11y_filtered.json", "x") as f:
+        axe = Axe(context.helperfunc.driver())
+        axe.write_results(
+            list(results_to_copy), f"{context.a11y_reports_dir}/a11y_filtered.json"
+        )

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -323,8 +323,8 @@ def check_accessibility(context, step_name):
 
 
 def filter_accessibility_report(context):
-    with open(f"{context.a11y_reports_dir}/a11y.json", "r") as f:
-        data = json.load(f)
+    f = open(f"{context.a11y_reports_dir}/a11y.json", "r")
+    data = json.load(f)
 
     results_to_copy = []
     for error in data:
@@ -333,8 +333,7 @@ def filter_accessibility_report(context):
         if not any(violations == issue["violations"] for issue in results_to_copy):
             results_to_copy.append(error)
 
-    with open(f"{context.a11y_reports_dir}/a11y_filtered.json", "x") as f:
-        axe = Axe(context.helperfunc.driver())
-        axe.write_results(
-            list(results_to_copy), f"{context.a11y_reports_dir}/a11y_filtered.json"
-        )
+    f = open(f"{context.a11y_reports_dir}/a11y_filtered.json", "x")
+    axe = Axe(context.helperfunc.driver())
+    axe.write_results(results_to_copy, f"{context.a11y_reports_dir}/a11y_filtered.json")
+    f.close()

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -329,7 +329,7 @@ def filter_accessibility_report(context):
     filtered_issues = []
     for step_error in reported_issues:
         violations = step_error["violations"]
-        # Check if the current violation is already in results_to_copy
+        # Check if the current violation is already in filtered_issues
         if not any(violations == issue["violations"] for issue in filtered_issues):
             filtered_issues.append(step_error)
 

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -300,20 +300,13 @@ def check_accessibility(context):
     time.sleep(0.6)
     axe = Axe(context.helperfunc.driver())
     axe.inject()
-    results = axe.run(
-        options={
-            "runOnly": {
-                "type": "rule",
-                "values": [
-                    "area-alt",
-                    "aria-allowed-attr",
-                    "color-contrast",
-                    "valid-lang",
-                ],
-            },
-            "resultTypes": ["violations", "incomplete"],
-        }
-    )
+    results = axe.run()
     if len(results["violations"]) > 0:
-        axe.write_results(results, f"{context.a11y_reports_dir}/a11y.json")
+        # TODO: Python dictionary with key of violations
+        # Append results violations to Python key
+        axe.write_results(
+            results["violations"] + results["incomplete"],
+            f"{context.a11y_reports_dir}/a11y.json",
+        )
+        # axe.report(results["violations"])
     return len(results["violations"]) == 0

--- a/behave/helper/helper_base.py
+++ b/behave/helper/helper_base.py
@@ -93,6 +93,9 @@ class HelperFunc(object):
     def get_current_path(self):
         return urlparse(self._driver.current_url).path
 
+    def get_url(self):
+        return self._driver.current_url
+
     def scroll_to_top(self):
         self._driver.execute_script("window.scrollTo(0, 0);")
 

--- a/behave/helper/helper_base.py
+++ b/behave/helper/helper_base.py
@@ -19,7 +19,6 @@ class HelperFunc(object):
         self.call_centre_backend = Backend("/call_centre/api/v1/")
         self.call_centre_backend.authenticate(**CALL_CENTRE_ZONE)
         today = datetime.now().date()
-        self.accessibility_check = False
         self.date_start_this_month = (today - timedelta(days=today.day)).replace(day=1)
 
     def driver(self):


### PR DESCRIPTION
## What does this pull request do?

Formatting axe.result dictionary file to only report points of interest in the a11y.json file. Report now only includes violations found in accessbility testing. This has been changed into a json format as well which has better readability.

After all of the tests have been run, the filter_accessibility_report() function creates a second  a11y_filtered.json which filters out and duplicated accessibility violations the report has found. 

## Any other changes that would benefit highlighting?

- Updated README.md file to include how to use accessibility tests in cla_end_to_end
- Updated Git Ignore to stop trying to include downloaded CSV files from tests into the repo
- Removed redundant class variable `accessibility_check = False`  

## Checklist

- [LGA-2411](https://dsdmoj.atlassian.net/browse/LGA-2411)

[LGA-2411]: https://dsdmoj.atlassian.net/browse/LGA-2411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ