### PR TITLE
LGA-2448 update end-to-end tests to reflect searching by only postcode

### DIFF
--- a/behave/features/cla_backend/backend_reports.feature
+++ b/behave/features/cla_backend/backend_reports.feature
@@ -1,3 +1,4 @@
+@cla_backend
 Feature: User journeys for Fox admin or cla_backend
 
 Background: Start page

--- a/behave/features/cla_backend/backend_users.feature
+++ b/behave/features/cla_backend/backend_users.feature
@@ -1,3 +1,4 @@
+@cla_backend
 Feature: User journeys for Fox admin or cla_backend to update the users staff status
 
 Background: Log in to the Fox admin as a user within the super users group

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -17,13 +17,14 @@ Feature: FALA end to end tests
 
 
   @fala-search-city @a11y-check
-  Scenario Outline: Search for legal advisers via city returns error
+  Scenario Outline: Search for legal advisers via invalid locations returns error
     Given I provide the "<location>" details
     When I select the "search" button on the FALA homepage
     Then A "Postcode not found" error is returned
     Examples:
       | location |
-      | London |
+      | London   |
+      | SWP 9AJ  |
 
 
   @fala-apply-filter-after-search @a11y-check
@@ -38,6 +39,14 @@ Feature: FALA end to end tests
     Examples:
       | location | filter_label |
       | SW1H 9AJ | crm          |
+
+
+ @fala-search-no-results @a11y-check
+  Scenario: I search for a town that does not have any solicitors and fails
+    Given I am on the Find a legal aid adviser homepage
+    And I provide an organisation name "Non existent org"
+    When I select the "search" button on the FALA homepage
+    Then no results are returned
 
 
   @fala-search-organisation @a11y-check

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -1,3 +1,4 @@
+@fala
 Feature: FALA end to end tests
   - Testing the search tool
   - Testing to apply filters to the search tool

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -6,15 +6,24 @@ Feature: FALA end to end tests
   Background: Homepage page
     Given I am on the Find a legal aid adviser homepage
 
-  @fala-search-location @a11y-check
-  Scenario Outline: Search for legal advisers via postcode and city
+  @fala-search-postcode @a11y-check
+  Scenario Outline: Search for legal advisers via postcode
     Given I provide the "<location>" details
     When I select the "search" button on the FALA homepage
     Then I am taken to the page corresponding to "<location>" result
     Examples:
       | location |
       | SW1H 9AJ |
-      | London   |
+
+
+  @fala-search-city @a11y-check
+  Scenario Outline: Search for legal advisers via city returns error
+    Given I provide the "<location>" details
+    When I select the "search" button on the FALA homepage
+    Then A "Postcode not found" error is returned
+    Examples:
+      | location |
+      | London |
 
 
   @fala-apply-filter-after-search @a11y-check
@@ -29,15 +38,6 @@ Feature: FALA end to end tests
     Examples:
       | location | filter_label |
       | SW1H 9AJ | crm          |
-      | London   | hou          |
-
-
-  @fala-search-no-results @a11y-check
-  Scenario: I search for a town that does not have any solicitors and fails
-    Given I am on the Find a legal aid adviser homepage
-    And I provide the "Heswall" details
-    When I select the "search" button on the FALA homepage
-    Then the page shows an error
 
 
   @fala-search-organisation @a11y-check
@@ -49,7 +49,7 @@ Feature: FALA end to end tests
     And 1 result is visible on the results page
     Examples:
       | location | organisation   |
-      | London   | Boothroyds LLP |
+      | SW1H 9AJ | Boothroyds LLP |
 
 
   @fala-dom-translation @a11y-check
@@ -73,4 +73,4 @@ Feature: FALA end to end tests
     And there are less results visible on the results page
     Examples:
       | location | filter_label |
-      | London   | edu          |
+      | SW1H 9AJ | edu          |

--- a/behave/features/cla_fala/fala_end_to_end_tests.feature
+++ b/behave/features/cla_fala/fala_end_to_end_tests.feature
@@ -17,8 +17,8 @@ Feature: FALA end to end tests
       | SW1H 9AJ |
 
 
-  @fala-search-city @a11y-check
-  Scenario Outline: Search for legal advisers via invalid locations returns error
+  @fala-search-not-valid @a11y-check
+  Scenario Outline: Search for legal advisers via invalid postcode or city returns error
     Given I provide the "<location>" details
     When I select the "search" button on the FALA homepage
     Then A "Postcode not found" error is returned

--- a/behave/features/cla_frontend/frontend_assignments.feature
+++ b/behave/features/cla_frontend/frontend_assignments.feature
@@ -1,3 +1,4 @@
+@cla_frontend
 Feature: - Assign alternative help to out of scope case.
          - Assign a case to a specialist provider.
          - Assign face to face.

--- a/behave/features/cla_frontend/frontend_create_case_and_user.feature
+++ b/behave/features/cla_frontend/frontend_create_case_and_user.feature
@@ -1,3 +1,4 @@
+@cla_frontend
 Feature: Case and user creation.
     Confirming that a case can be created and then a new User 
     linked with the case.

--- a/behave/features/cla_frontend/frontend_existing_callback.feature
+++ b/behave/features/cla_frontend/frontend_existing_callback.feature
@@ -1,3 +1,4 @@
+@cla_frontend
 Feature: Check Callbacks for Digital Cases
 # Looking at the callbacks calendar view to see whether callbacks have been created and then viewing the cases
 

--- a/behave/features/cla_frontend/frontend_means_test.feature
+++ b/behave/features/cla_frontend/frontend_means_test.feature
@@ -1,3 +1,4 @@
+@cla_frontend
 Feature: Means test assessment
     Confirming if a person is eligible or not for legal aid and can be assigned a provider
 

--- a/behave/features/cla_frontend/frontend_specialist_provider.feature
+++ b/behave/features/cla_frontend/frontend_specialist_provider.feature
@@ -1,3 +1,4 @@
+@cla_frontend
 Feature: Specialist Provider Case Assignment
 # Testing fixture used is loaded as part of creat_db.sh file.
 

--- a/behave/features/cla_public/public_contact_us.feature
+++ b/behave/features/cla_public/public_contact_us.feature
@@ -1,4 +1,5 @@
- Feature: Contact us link
+@cla_public
+Feature: Contact us link
      As a CLA/FALA developer, I want to test the contact us journey,
      so that I can complete the e2e test journey.
 

--- a/behave/features/cla_public/public_eligible.feature
+++ b/behave/features/cla_public/public_eligible.feature
@@ -1,3 +1,4 @@
+@cla_public
 Feature:
   - In scope means tests and some with callback or confirmation details after successful means test
   - Out of scope means tests

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -1,4 +1,9 @@
-from helper.constants import CLA_FALA_URL, FALA_HEADER, MINIMUM_SLEEP_SECONDS
+from helper.constants import (
+    CLA_FALA_URL,
+    FALA_HEADER,
+    MINIMUM_SLEEP_SECONDS,
+    ERROR_TITLE,
+)
 from behave import step
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
@@ -200,7 +205,6 @@ def step_impl_postcode_not_found_error_returned(context, message):
         ".govuk-error-summary__body"
     )
 
-    assert error_title is not None
-    assert error_message is not None
-    assert error_title.text == "There is a problem"
+    assert error_title, error_message is not None
+    assert error_title.text == ERROR_TITLE
     assert error_message.text == message, f"actual error message is {error_message}"

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -191,3 +191,16 @@ def step_impl_resulting_generic_search(context, location):
         And I am taken to the page corresponding to "{location}" result
     """
     )
+
+
+@step('A "{message}" error is returned')
+def step_impl_postcode_not_found_error_returned(context, message):
+    error_title = context.helperfunc.find_by_css_selector(".govuk-error-summary__title")
+    error_message = context.helperfunc.find_by_css_selector(
+        ".govuk-error-summary__body"
+    )
+
+    assert error_title is not None
+    assert error_message is not None
+    assert error_title.text == "There is a problem"
+    assert error_message.text == message, f"actual error message is {error_message}"

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -96,7 +96,7 @@ def step_impl_apply_filter_on_result_page(context, location, filter_label):
     assert_result_page(context, expected_url, expected_title)
 
 
-@step("the page shows an error")
+@step("no results are returned")
 def step_impl_error_shown_on_page(context):
     alert = context.helperfunc.find_by_css_selector(".alert-message")
     assert alert is not None

--- a/behave/helper/constants.py
+++ b/behave/helper/constants.py
@@ -195,3 +195,4 @@ CLA_CONTACT_US_USER_PERSON_TO_CALL = "Elena Fisher"
 MINIMUM_SLEEP_SECONDS = 2
 
 FALA_HEADER = "Find a legal aid adviser or family mediator"
+ERROR_TITLE = "There is a problem"


### PR DESCRIPTION
## What does this pull request do?

FALA no longer allows searching by city. This PR updates our end to end tests to reflect this.

- Most tests that had used "London" have been replaced with a postcode. 
- A test has been added to check that an error is returned when a user searches by city or when an invalid postcode is used
- The search no results test scenario has been edited to check when searching for an organisation that does not exist. This is because when a user searches for any valid postcode, it will always return the nearest available organisation 

## Any other changes that would benefit highlighting?

Added tags on the top of each .feature file to allow us to call specific tests in our repository pipelines

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"