### PR TITLE
LGA-2303 update test to pass out of hours

### DIFF
--- a/behave/features/cla_frontend/frontend_means_test.feature
+++ b/behave/features/cla_frontend/frontend_means_test.feature
@@ -8,7 +8,8 @@ Background: Login
 @means_test_universal
 Scenario: Successful means test assessment resulting in user being eligible for legal aid
     Given I select to 'Create a case'
-    And I am on the Finances tab with the ‘Details’ sub-tab preselected
+    And I have created a valid discrimination scope
+    And I am taken to the "Finances" tab with the ‘Details’ sub-tab preselected
     When I am not aged 17 or under
     And I do not have a partner
     And I am not aged 60 or over

--- a/behave/features/cla_frontend/frontend_means_test.feature
+++ b/behave/features/cla_frontend/frontend_means_test.feature
@@ -8,8 +8,7 @@ Background: Login
 @means_test_universal
 Scenario: Successful means test assessment resulting in user being eligible for legal aid
     Given I select to 'Create a case'
-    And I have created a valid discrimination scope
-    And I am taken to the "Finances" tab with the ‘Details’ sub-tab preselected
+    And I am on the Finances tab with the ‘Details’ sub-tab preselected
     When I am not aged 17 or under
     And I do not have a partner
     And I am not aged 60 or over

--- a/behave/features/cla_public/public_contact_us.feature
+++ b/behave/features/cla_public/public_contact_us.feature
@@ -7,7 +7,7 @@ Feature: Contact us link
      Given I have selected the start now button on the start page
 
 # Journey P9, Tickets combined (LGA-1874,LGA-2106)
-@cla-contact-us-link-journey, @a11y-check
+@cla-contact-us-link-journey @a11y-check
 Scenario: contact us journey to contact civil legal advice page / form
     Given I select 'Contact us' from the banner
     And I select <question> from the contact civil legal advice page
@@ -21,7 +21,7 @@ Scenario: contact us journey to contact civil legal advice page / form
     Then I am taken to the "Your details have been submitted" page located on "/result/confirmation"
 
 # Journey P9, Ticket (LGA-2183)
-@cla-contact-us-call-someone-else, @a11y-check
+@cla-contact-us-call-someone-else @a11y-check
 Scenario: contact us journey, selecting 'call someone else instead of me' option
   Given I am on the Contact Civil Legal Advice page
   When I enter a name in the 'Your full name' field
@@ -29,7 +29,6 @@ Scenario: contact us journey, selecting 'call someone else instead of me' option
   And I enter the full name of the person to call
   And I select "Family member or friend" from the 'Relationship to you' drop down options
   And I enter the phone number of the person to call back
-  And I select 'Call today'
-  And I select an available "thirdparty" call time
+  And I select the next available "thirdparty" time slot
   And I select 'Submit details'
   Then I am taken to the "We will call you back" page located on "/result/confirmation"

--- a/behave/features/steps/frontend_means_test.py
+++ b/behave/features/steps/frontend_means_test.py
@@ -1,6 +1,5 @@
 from behave import step
 import re
-from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -34,10 +33,8 @@ def step_impl_finance_details_tabs(context):
 
 @step("I move onto {tab_name} inner-tab")
 def step_impl_move_to_tab(context, tab_name):
-    xpath_scroll = "//form/div[contains(@class,'Toolbar')]"
     page = context.helperfunc
-    actions = ActionChains(page.driver())
-    actions.move_to_element(page.find_by_xpath(xpath_scroll)).perform()
+    context.helperfunc.scroll_to_top()
 
     xpath = f"//ul[@id='pills-section-list']/li/a[text()='{tab_name}']"
     WebDriverWait(page.driver(), 10).until(

--- a/behave/features/steps/frontend_means_test.py
+++ b/behave/features/steps/frontend_means_test.py
@@ -1,5 +1,8 @@
 from behave import step
 import re
+
+from selenium.common.exceptions import ElementClickInterceptedException
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -33,10 +36,25 @@ def step_impl_finance_details_tabs(context):
 
 @step("I move onto {tab_name} inner-tab")
 def step_impl_move_to_tab(context, tab_name):
+    xpath_scroll = "//form/div[contains(@class,'Toolbar')]"
     page = context.helperfunc
-    context.helperfunc.scroll_to_top()
+    actions = ActionChains(page.driver())
+    actions.move_to_element(page.find_by_xpath(xpath_scroll)).perform()
 
     xpath = f"//ul[@id='pills-section-list']/li/a[text()='{tab_name}']"
+
+    def is_tab_option_clickable(*args):
+        try:
+            WebDriverWait(page.driver(), 10).until(
+                EC.element_to_be_clickable((By.XPATH, xpath))
+            ).click()
+            return True
+        except ElementClickInterceptedException:
+            return False
+
+    if is_tab_option_clickable() is False:
+        context.helperfunc.scroll_to_top()
+
     WebDriverWait(page.driver(), 10).until(
         EC.element_to_be_clickable((By.XPATH, xpath))
     ).click()

--- a/behave/features/steps/public_contact_us.py
+++ b/behave/features/steps/public_contact_us.py
@@ -99,46 +99,28 @@ def step_impl_select_next_available_time_slot(context, option):
         )
         call_today.click()
         assert call_today.get_attribute("value") == "today"
-
-        choose_callback_time = Select(
-            context.callback_form.find_element_by_xpath(
-                f'//select[@id="{option}-time-time_today"]'
-            )
+        assert_select_first_dropdown(
+            context, f'//select[@id="{option}-time-time_today"]'
         )
-
-        assert choose_callback_time is not None
-        if len(choose_callback_time.options) > 0:
-            choose_callback_time.select_by_index(1)
-        else:
-            raise AssertionError("No option to callback time")
     else:
         specific_day = context.callback_form.find_element_by_xpath(
             '//input[@value="specific_day"]' '[@id="thirdparty-time-specific_day-1"]'
         )
         specific_day.click()
         assert specific_day.get_attribute("value") == "specific_day"
-
-        choose_callback_time = Select(
-            context.callback_form.find_element_by_xpath(
-                f'//select[@id="{option}-time-day"]'
-            )
+        assert_select_first_dropdown(context, f'//select[@id="{option}-time-day"]')
+        assert_select_first_dropdown(
+            context, f'//select[@id="{option}-time-time_in_day"]'
         )
-        assert choose_callback_time is not None
-        if len(choose_callback_time.options) > 0:
-            choose_callback_time.select_by_index(1)
-        else:
-            raise AssertionError("No option to callback time")
 
-        choose_callback_time = Select(
-            context.callback_form.find_element_by_xpath(
-                f'//select[@id="{option}-time-time_in_day"]'
-            )
-        )
-        assert choose_callback_time is not None
-        if len(choose_callback_time.options) > 0:
-            choose_callback_time.select_by_index(1)
-        else:
-            raise AssertionError("No option to callback time")
+
+def assert_select_first_dropdown(context, xpath_id):
+    choose_first_item = Select(context.callback_form.find_element_by_xpath(xpath_id))
+    assert choose_first_item is not None
+    if len(choose_first_item.options) > 0:
+        choose_first_item.select_by_index(1)
+    else:
+        raise AssertionError(f"No option in dropdown menu {xpath_id}")
 
 
 # call someone else instead of me name input field


### PR DESCRIPTION
## What does this pull request do?

Fixes 2 failing tests:
1. Makes the **call someone else instead of me** test scenario pass when run out of hours (after 5:30pm). This test would fail after 5:30pm as the 'Call Today' option would disappear. If the 'Not Today' option is not visible, then it will select the next available option (call another day).
-  public_contact_us.feature
- public_contact_us.py
2. "**Successful means test assessment resulting in user being eligible for legal aid**" - this has been failing in the pipeline regularly on the `And I move onto Finances inner-tab` step. Screenshots on failure show that the tab was not visible, I have forced it to scroll to the top in this scenario. 
- frontend_means_test.py

## Any other changes that would benefit highlighting?

Proof that the first test passes out of hours in [this run](https://app.circleci.com/pipelines/github/ministryofjustice/cla-end-to-end-tests/930/workflows/57258896-f6c2-4059-aaff-942a1b3dc7ea/jobs/2634) that occurred after 6pm.


I originally updated the second failing test to always scroll up. However, doing this would make 3 other tests consistently fail. So I have forced it to scroll when the `ElementClickInterceptedException` has occurred.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"