### PR TITLE
LGA-2642 adding irsa circleci access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,9 @@
 version: 2.1
 orbs:
-  aws-cli: circleci/aws-cli@4.0.0 # use v4 of this orb
+  aws-cli: circleci/aws-cli@4.0.0
   aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
   orb-tools: circleci/orb-tools@10.1.0
+
 
 jobs:
   behave:
@@ -16,25 +17,48 @@ jobs:
           command: |
             pip install pre-commit==2.17.0
             pre-commit run --all-files
+
+#       Pull public image
+      - aws-cli/setup:
+          role_arn: $CLA_PUBLIC_ECR_ROLE_TO_ASSUME # this will use the env var
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clapublic
+        
+
+      # Pull cla_backend image
+      - aws-cli/setup:
+          role_arn: $CLA_BACKEND_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clabackend
+
+#       Pull cla_frontend image
+      - aws-cli/setup:
+          role_arn: $CLA_FRONTEND_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clafrontend
+
+#       Pull socket_server image
+      - aws-cli/setup:
+          role_arn: $SOCKET_SERVER_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clasocketserver
+
+      # Pull fala image
+      - aws-cli/setup:
+          role_arn: $FALA_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images fala
+
       - run:
-          name: Install compatible docker-compose
-          command: pip install docker-compose==1.27.4
-      - run:
-          name: Authenticate with awscli
-          command: |
-            pip install awscli
-            login="$(aws ecr get-login --region eu-west-2 --no-include-email)"
-            ${login}
-      - run:
-          name: Build / pull Docker images
+          name: Build / Check services are up
           command: |
             cd behave
-            docker-compose pull
             docker-compose build
-      - run:
-          name: Check services are up
-          command: |
-            cd behave
             docker-compose run start_applications
             docker-compose exec clabackend bin/create_db.sh
       - run:
@@ -75,8 +99,8 @@ jobs:
       - aws-ecr/build-image:
           push-image: true
           tag: $BUILD_TAGS
-          region: $ECR_REGION # this will use the env var
-          repo: $ECR_REPOSITORY # this will use the env var
+          region: $ECR_REGION
+          repo: $ECR_REPOSITORY
 workflows:
   build:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
 workflows:
   build:
     jobs:
-      - build
+#      - build
       - orb-tools/publish-dev:
           name: publish_dev_orb
           attach-workspace: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,4 +126,4 @@ workflows:
             branches:
               only:
                 - main
-      - behave
+#      - behave

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
-  aws-ecr: circleci/aws-ecr@7.3.0
+  aws-cli: circleci/aws-cli@4.0.0 # use v4 of this orb
+  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
   orb-tools: circleci/orb-tools@10.1.0
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ orbs:
   aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
   orb-tools: circleci/orb-tools@10.1.0
 
-
 jobs:
   behave:
     docker:
@@ -77,34 +76,9 @@ jobs:
           path: behave/data
           destination: data
 
-  build:
-    executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
-    steps:
-      # Checkout your repository
-      - checkout
-      # Authenticate to AWS using OIDC v2 with the AWS CLI
-      - aws-cli/setup:
-          role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
-          region: $ECR_REGION # this will use the env var
-      # Authenticate to the ECR repository using the standard command
-      - run: |
-          aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
-      # Build and push your Docker image
-      - run:
-          name: Create target tag for main application image
-          command: |
-            source .circleci/define_build_environment_variables
-            echo "Created tags $TARGET_TAGS"
-            echo "export BUILD_TAGS=$TARGET_TAGS" >> $BASH_ENV
-      - aws-ecr/build-image:
-          push-image: true
-          tag: $BUILD_TAGS
-          region: $ECR_REGION
-          repo: $ECR_REPOSITORY
 workflows:
   build:
     jobs:
-#      - build
       - orb-tools/publish-dev:
           name: publish_dev_orb
           attach-workspace: false
@@ -126,4 +100,4 @@ workflows:
             branches:
               only:
                 - main
-#      - behave
+      - behave

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,21 +53,34 @@ jobs:
           path: behave/data
           destination: data
 
+  build:
+    executor: aws-ecr/default # use the aws-ecr/default executor to start the docker daemon
+    steps:
+      # Checkout your repository
+      - checkout
+      # Authenticate to AWS using OIDC v2 with the AWS CLI
+      - aws-cli/setup:
+          role_arn: $ECR_ROLE_TO_ASSUME # this will use the env var
+          region: $ECR_REGION # this will use the env var
+      # Authenticate to the ECR repository using the standard command
+      - run: |
+          aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
+      # Build and push your Docker image
+      - run:
+          name: Create target tag for main application image
+          command: |
+            source .circleci/define_build_environment_variables
+            echo "Created tags $TARGET_TAGS"
+            echo "export BUILD_TAGS=$TARGET_TAGS" >> $BASH_ENV
+      - aws-ecr/build-image:
+          push-image: true
+          tag: $BUILD_TAGS
+          region: $ECR_REGION # this will use the env var
+          repo: $ECR_REPOSITORY # this will use the env var
 workflows:
   build:
     jobs:
-      - aws-ecr/build-and-push-image:
-          name: Build and push
-          repo: "${AWS_RESOURCE_NAME_PREFIX}"
-          tag: "${CIRCLE_SHA1}"
-      - aws-ecr/build-and-push-image:
-          name: Build and push latest tag
-          repo: "${AWS_RESOURCE_NAME_PREFIX}"
-          tag: "latest"
-          filters:
-            branches:
-              only:
-                - main
+      - build
       - orb-tools/publish-dev:
           name: publish_dev_orb
           attach-workspace: false

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,8 +1,0 @@
-#!/bin/sh -eu
-
-safe_git_branch=${CIRCLE_BRANCH//\//-}
-if [ "$CIRCLE_BRANCH" == "master" ]; then
-  export TARGET_TAGS="$safe_git_branch,latest"
-else
-  export TARGET_TAGS="$safe_git_branch,$CIRCLE_SHA1"
-fi

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,0 +1,7 @@
+#!/bin/sh -eu
+
+if [ "$CIRCLE_BRANCH" == "master" ]; then
+  export TARGET_TAGS="latest"
+else
+  export TARGET_TAGS=$CIRCLE_SHA1
+fi

--- a/.circleci/define_build_environment_variables
+++ b/.circleci/define_build_environment_variables
@@ -1,7 +1,8 @@
 #!/bin/sh -eu
 
+safe_git_branch=${CIRCLE_BRANCH//\//-}
 if [ "$CIRCLE_BRANCH" == "master" ]; then
-  export TARGET_TAGS="latest"
+  export TARGET_TAGS="$safe_git_branch,latest"
 else
-  export TARGET_TAGS=$CIRCLE_SHA1
+  export TARGET_TAGS="$safe_git_branch,$CIRCLE_SHA1"
 fi

--- a/.circleci/pull_images
+++ b/.circleci/pull_images
@@ -1,0 +1,5 @@
+#!/bin/bash
+DOCKER_COMPOSE_SERVICE_NAME=$1
+cd behave
+aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
+docker-compose pull $DOCKER_COMPOSE_SERVICE_NAME

--- a/orb.yml
+++ b/orb.yml
@@ -1,24 +1,55 @@
 version: 2.1
 description: The end-to-end test suite for use in CLA app pipelines
+orbs:
+  aws-cli: circleci/aws-cli@4.0.0
+  aws-ecr: circleci/aws-ecr@8.2.1 # this orb doesn't support OIDC v2, so we use aws-cli to authenticate
 
 commands:
   behave:
     description: Run the CLA apps in a docker cluster and run the Behave test suite against them
     steps:
       - setup_remote_docker
+#       Pull public image
+      - aws-cli/setup:
+          role_arn: $CLA_PUBLIC_ECR_ROLE_TO_ASSUME # this will use the env var
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clapublic
+        
+
+      # Pull cla_backend image
+      - aws-cli/setup:
+          role_arn: $CLA_BACKEND_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clabackend
+
+#       Pull cla_frontend image
+      - aws-cli/setup:
+          role_arn: $CLA_FRONTEND_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clafrontend
+
+#       Pull socket_server image
+      - aws-cli/setup:
+          role_arn: $SOCKET_SERVER_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images clasocketserver
+
+      # Pull fala image
+      - aws-cli/setup:
+          role_arn: $FALA_ECR_ROLE_TO_ASSUME
+          region: $ECR_REGION
+      - run: |
+          ./.circleci/pull_images fala
+
       - run:
-          name: Authenticate with awscli
+          name: Build / Check services are up
           command: |
-            login="$(aws ecr get-login --region eu-west-2 --no-include-email)"
-            ${login}
-      - run:
-          name: Build / pull Docker images
-          command: |
-            docker-compose pull
+            cd behave
             docker-compose build
-      - run:
-          name: Check services are up
-          command: |
             docker-compose run start_applications
             docker-compose exec clabackend bin/create_db.sh
       - run:

--- a/orb.yml
+++ b/orb.yml
@@ -7,58 +7,72 @@ orbs:
 commands:
   behave:
     description: Run the CLA apps in a docker cluster and run the Behave test suite against them
+
     steps:
-      - setup_remote_docker
-#       Pull public image
-      - aws-cli/setup:
-          role_arn: $CLA_PUBLIC_ECR_ROLE_TO_ASSUME # this will use the env var
-          region: $ECR_REGION
       - run: |
+          export E2E_WORKING_DIRECTORY=/tmp/cla-end-to-end-tests
+          echo "export E2E_WORKING_DIRECTORY=$E2E_WORKING_DIRECTORY"  >> $BASH_ENV
+          mkdir -p $E2E_WORKING_DIRECTORY
+          echo "E2E_WORKING_DIRECTORY is $E2E_WORKING_DIRECTORY"
+          echo "E2E_BRANCH is $E2E_BRANCH"
+          git clone --single-branch --branch ${E2E_BRANCH:-main} git@github.com:ministryofjustice/cla-end-to-end-tests.git $E2E_WORKING_DIRECTORY
+
+      # Pull cla_public image
+      - aws-cli/setup:
+          role_arn: $CLA_PUBLIC_ECR_ROLE_TO_ASSUME
+          region: ECR_REGION
+      - run: |
+          cd $E2E_WORKING_DIRECTORY
           ./.circleci/pull_images clapublic
-        
 
       # Pull cla_backend image
       - aws-cli/setup:
           role_arn: $CLA_BACKEND_ECR_ROLE_TO_ASSUME
-          region: $ECR_REGION
+          region: ECR_REGION
       - run: |
+          cd $E2E_WORKING_DIRECTORY
           ./.circleci/pull_images clabackend
 
-#       Pull cla_frontend image
+      # Pull cla_frontend image
       - aws-cli/setup:
           role_arn: $CLA_FRONTEND_ECR_ROLE_TO_ASSUME
-          region: $ECR_REGION
+          region: ECR_REGION
       - run: |
+          cd $E2E_WORKING_DIRECTORY
           ./.circleci/pull_images clafrontend
 
-#       Pull socket_server image
+       # Pull socket_server image
       - aws-cli/setup:
           role_arn: $SOCKET_SERVER_ECR_ROLE_TO_ASSUME
-          region: $ECR_REGION
+          region: ECR_REGION
       - run: |
+          cd $E2E_WORKING_DIRECTORY
           ./.circleci/pull_images clasocketserver
 
       # Pull fala image
       - aws-cli/setup:
           role_arn: $FALA_ECR_ROLE_TO_ASSUME
-          region: $ECR_REGION
+          region: ECR_REGION
       - run: |
+          cd $E2E_WORKING_DIRECTORY
           ./.circleci/pull_images fala
 
       - run:
-          name: Build / Check services are up
+          name: Check services are up
           command: |
-            cd behave
+            cd $E2E_WORKING_DIRECTORY/behave
             docker-compose build
             docker-compose run start_applications
             docker-compose exec clabackend bin/create_db.sh
       - run:
           name: Run behave tests
           command: |
+            cd $E2E_WORKING_DIRECTORY/behave
             docker-compose run --name cla-end-to-end cla-end-to-end
       - run:
           name: Copy artifacts
           command: |
+            cd $E2E_WORKING_DIRECTORY/behave
             echo "Manually copying files because circleci docker executor does not support volumes"
             echo "https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-mount-volumes-to-docker-containers-"
             mkdir -p /tmp/end-to-end-data
@@ -67,10 +81,3 @@ commands:
       - store_artifacts:
           path: /tmp/end-to-end-data
           destination: data
-
-jobs:
-  behave:
-    docker:
-      - image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/laa-get-access/laa-cla-end-to-end-tests-ecr:${CLA_E2E_IMAGE_VERSION:-latest}"
-    steps:
-      - behave


### PR DESCRIPTION
## What does this pull request do?

- Removed the building of the end-to-end image
- Updated behave job to pull images using OIDC 
- Updated Orb to pull images using OIDC 

## Any other changes that would benefit highlighting?

### Removed the building of the end-to-end image
Previously the resulting image was being used by the `ministryofjustice/cla-end-to-end-tests` orb. It was being used as the base image for the environment that the end-to-end tests ran on. This meant that in which ever pipeline the orb was used in, it always had access to the end-to-end files.
The new OIDC method(how cloud-platform set it up) doesn't allow us to use docker executor with an image from our private ecr repository. So instead we use a machine executor and checkout the end-to-end code when the orb is running.

### docker pull
The `ministryofjustice/cla-end-to-end-tests` orb needs to pull images from multiple ecr repos. Previously it just needed to authenticate once with an access key and secret key and we could access all our repos. With the new OIDC authentication (how cloud-platforms set it up) each repo has an associated role and you need to assume the role associated with the repo to pull an image down from it. So instead of having a single docker pull, we now have 5 with each authenticating to a different repository.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"