### PR TITLE
LGA-2693: Fixed 'Exit this Page' behave tests

### DIFF
--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -10,7 +10,7 @@ from helper.constants import BBC_WEBSITE
 @step('The "Exit this page" button is on the page and I click it')
 def step_impl_click_exit_page(context):
     href_bbc_address = context.helperfunc.find_by_xpath(
-        "//main/div/div/a[contains(text(), 'Exit this page')]"
+        "//main/div[1]/a[contains(text(), 'Exit this page')]"
     ).get_attribute("href")
 
     assert href_bbc_address == BBC_WEBSITE

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -4,7 +4,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
-from helper.constants import BBC_WEBSITE
+from helper.constants import BBC_WEBSITE, BBC_INTERNATIONAL_WEBSITE
 
 
 @step('The "Exit this page" button is on the page and I click it')
@@ -34,5 +34,4 @@ def step_impl_keypress_multiple_times(context, keypress, amount_of_time):
 
 @step("I am diverted to the BBC website")
 def step_impl_diversion_link(context):
-    print(context.helperfunc.get_url())
-    assert context.helperfunc.get_url() == BBC_WEBSITE
+    assert context.helperfunc.get_url() == BBC_INTERNATIONAL_WEBSITE

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -9,8 +9,12 @@ from helper.constants import BBC_WEBSITE
 
 @step('The "Exit this page" button is on the page and I click it')
 def step_impl_click_exit_page(context):
-    href_bbc_address = context.helperfunc.find_by_xpath("//*[@id='main-content']/div[1]/a").get_attribute("href")
+    href_bbc_address = context.helperfunc.find_by_xpath(
+        "//main/div/div/a[contains(text(), 'Exit this page')]"
+    ).get_attribute("href")
+
     assert href_bbc_address == BBC_WEBSITE
+
     context.helperfunc.click_button(By.CLASS_NAME, "govuk-exit-this-page")
 
 

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -34,4 +34,5 @@ def step_impl_keypress_multiple_times(context, keypress, amount_of_time):
 
 @step("I am diverted to the BBC website")
 def step_impl_diversion_link(context):
+    print(context.helperfunc.get_url())
     assert context.helperfunc.get_url() == BBC_WEBSITE

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -10,9 +10,7 @@ from helper.constants import BBC_WEBSITE
 @step('The "Exit this page" button is on the page and I click it')
 def step_impl_click_exit_page(context):
     href_bbc_address = context.helperfunc.find_by_xpath("//*[@id='main-content']/div[1]/a").get_attribute("href")
-
     assert href_bbc_address == BBC_WEBSITE
-
     context.helperfunc.click_button(By.CLASS_NAME, "govuk-exit-this-page")
 
 

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -9,9 +9,7 @@ from helper.constants import BBC_WEBSITE
 
 @step('The "Exit this page" button is on the page and I click it')
 def step_impl_click_exit_page(context):
-    href_bbc_address = context.helperfunc.find_by_xpath(
-        "//main/div/div/a[contains(text(), 'Exit this page')]"
-    ).get_attribute("href")
+    href_bbc_address = context.helperfunc.find_by_xpath("//*[@id='main-content']/div[1]/a").get_attribute("href")
 
     assert href_bbc_address == BBC_WEBSITE
 

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -34,4 +34,5 @@ def step_impl_keypress_multiple_times(context, keypress, amount_of_time):
 
 @step("I am diverted to the BBC website")
 def step_impl_diversion_link(context):
-    assert context.helperfunc.get_url() == BBC_INTERNATIONAL_WEBSITE
+    # Depending on where in the world the test is executed you will either be directed to bbc.co.uk or bbc.com
+    assert context.helperfunc.get_url() in [BBC_WEBSITE, BBC_INTERNATIONAL_WEBSITE]

--- a/behave/helper/constants.py
+++ b/behave/helper/constants.py
@@ -215,4 +215,4 @@ MINIMUM_SLEEP_SECONDS = 2
 
 FALA_HEADER = "Find a legal aid adviser or family mediator"
 ERROR_TITLE = "There is a problem"
-BBC_WEBSITE = "https://www.bbc.co.uk/weather"
+BBC_WEBSITE = "https://www.bbc.com/weather"

--- a/behave/helper/constants.py
+++ b/behave/helper/constants.py
@@ -215,4 +215,5 @@ MINIMUM_SLEEP_SECONDS = 2
 
 FALA_HEADER = "Find a legal aid adviser or family mediator"
 ERROR_TITLE = "There is a problem"
-BBC_WEBSITE = "https://www.bbc.com/weather"
+BBC_WEBSITE = "https://www.bbc.co.uk/weather"
+BBC_INTERNATIONAL_WEBSITE = "https://www.bbc.com/weather"


### PR DESCRIPTION
## What does this pull request do?

### Fixes the 'Exit this Page' behave tests failing in the CircleCI pipeline:
- #### Updates the 'Exit this Page' component's xpath in the public_exit_page behave tests. 
   - This is required to reflect the new location of the 'Exit this Page' component in the DOM.
- #### Adds a new valid redirection URL for the `I am diverted to the BBC website` behave test. 
   - This is required as CircleCI is probably running their servers outside the UK, so their DNS is redirecting them to 
 www.bbc.com rather than www.bbc.co.uk- causing the tests to fail.

## Any other changes that would benefit highlighting?

- A new constant, `BBC_INTERNATIONAL_WEBSITE`, with a value of "https://www.bbc.com" was added to the `helper.constants` namespace

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"