### PR TITLE
LGA-2604 Resolving incorrect xpath to exit page button and assert err…

### DIFF
--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -10,7 +10,7 @@ from helper.constants import BBC_WEBSITE
 @step('The "Exit this page" button is on the page and I click it')
 def step_impl_click_exit_page(context):
     href_bbc_address = context.helperfunc.find_by_xpath(
-        "//main/div/div/a[contains(text(), 'Exit this page')]"
+        "//main/div/a[contains(text(), 'Exit this page')]"
     ).get_attribute("href")
 
     assert href_bbc_address == BBC_WEBSITE
@@ -34,4 +34,6 @@ def step_impl_keypress_multiple_times(context, keypress, amount_of_time):
 
 @step("I am diverted to the BBC website")
 def step_impl_diversion_link(context):
-    assert context.helperfunc.get_url() == BBC_WEBSITE
+    assert (
+        context.helperfunc.get_url() == BBC_WEBSITE
+    ), f"Url is {context.helperfunc.get_url()}, expected {BBC_WEBSITE}"

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -4,7 +4,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.keys import Keys
 
-from helper.constants import BBC_WEBSITE
+from helper.constants import BBC_WEBSITE, BBC_INTERNATIONAL_WEBSITE
 
 
 @step('The "Exit this page" button is on the page and I click it')
@@ -34,6 +34,8 @@ def step_impl_keypress_multiple_times(context, keypress, amount_of_time):
 
 @step("I am diverted to the BBC website")
 def step_impl_diversion_link(context):
-    assert (
-        context.helperfunc.get_url() == BBC_WEBSITE
-    ), f"Url is {context.helperfunc.get_url()}, expected {BBC_WEBSITE}"
+    # Depending on where in the world the test is executed you will either be directed to bbc.co.uk or bbc.com
+    assert context.helperfunc.get_url() in [
+        BBC_WEBSITE,
+        BBC_INTERNATIONAL_WEBSITE,
+    ], f"Url is {context.helperfunc.get_url()}, expected {BBC_WEBSITE}"

--- a/behave/features/steps/public_exit_page.py
+++ b/behave/features/steps/public_exit_page.py
@@ -38,4 +38,4 @@ def step_impl_diversion_link(context):
     assert context.helperfunc.get_url() in [
         BBC_WEBSITE,
         BBC_INTERNATIONAL_WEBSITE,
-    ], f"Url is {context.helperfunc.get_url()}, expected {BBC_WEBSITE}"
+    ], f"Url is {context.helperfunc.get_url()}"

--- a/behave/helper/constants.py
+++ b/behave/helper/constants.py
@@ -216,3 +216,4 @@ MINIMUM_SLEEP_SECONDS = 2
 FALA_HEADER = "Find a legal aid adviser or family mediator"
 ERROR_TITLE = "There is a problem"
 BBC_WEBSITE = "https://www.bbc.co.uk/weather"
+BBC_INTERNATIONAL_WEBSITE = "https://www.bbc.com/weather"


### PR DESCRIPTION
## What does this pull request do?

[LGA-2604](https://dsdmoj.atlassian.net/browse/LGA-2604) Exit Page work has some last minute HTML changes that needed to be reflected in the end to end test, resulting in an Xpath fail. 

The BBC URL also changes depending on the test region, which resulted in going to BBC.COM and not BBC.CO.UK. 

## Any other changes that would benefit highlighting?

Updated Xpath
Checks for BBC.CO.UK and BBC.COM

## Checklist

[LGA-2604](https://dsdmoj.atlassian.net/browse/LGA-2604)

[LGA-2604]: https://dsdmoj.atlassian.net/browse/LGA-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LGA-2604]: https://dsdmoj.atlassian.net/browse/LGA-2604?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ