### PR TITLE
LGA 2705: Fix scope decision integration test failing too often

### DIFF
--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -160,8 +160,18 @@ def step_impl_select_diagnosis_category(context):
 
 @step('I get an "{scope}" decision')
 def step_impl_scope_decision(context, scope):
-    text = context.helperfunc.find_by_name("diagnosis-form").text
-    assert scope in text
+    summary_block_content = context.helperfunc.find_many_by_class(
+        "SummaryBlock-content"
+    )
+
+    summary_text = []
+
+    for element in summary_block_content:
+        summary_text.append(element.text)
+
+    assert (
+        scope in summary_text
+    ), f"The diagnosis form contained the following text: {summary_text}, but did not find: {scope}"
 
 
 @step('select the "{button_text}" button')


### PR DESCRIPTION
## What does this pull request do?
### [LGA 2705](https://dsdmoj.atlassian.net/jira/software/c/projects/LGA/boards/226?modal=detail&selectedIssue=LGA-2705)

- Changes how the scope integration test works.
    - Before: Waits for element "decision-form" to be loaded, this is a parent element to a number of text fields.
    - After: Loads in the multiple child elements by their class name. This should allow us to wait until they are all loaded before we assert what their text contains.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"