### PR TITLE
LGA-2705 fix scope decision test failing too often

### DIFF
--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -166,16 +166,11 @@ def step_impl_scope_decision(context, scope):
     try:
         scope_decision = context.helperfunc.find_by_xpath(scope_xpath)
     except TimeoutException:
-        print("The scope element could not be found")
-        assert False
-    else:
-        print(type(scope_decision))
-        print(scope_decision)
-        print(scope_decision.text)
+        assert False, f"The scope element could not be found with xpath: {scope_xpath}"
 
     assert (
         scope in scope_decision.text
-    ), f"The diagnosis form contained the following text: {scope_decision.text}, but did not find: {scope}"
+    ), f"The scope_decision element : {scope_decision}, was found, and contained the following text: {scope_decision.text}.\n But was looking to find: {scope}"
 
 
 @step('select the "{button_text}" button')

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -161,9 +161,7 @@ def step_impl_select_diagnosis_category(context):
 
 @step('I get an "{scope}" decision')
 def step_impl_scope_decision(context, scope):
-    scope_xpath = (
-        f"//p[contains(text(), '{scope}')]"
-    )
+    scope_xpath = f"//p[contains(text(), '{scope}')]"
 
     try:
         scope_decision = context.helperfunc.find_by_xpath(scope_xpath)

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -169,10 +169,11 @@ def step_impl_scope_decision(context, scope):
         scope_decision = context.helperfunc.find_by_xpath(scope_xpath)
     except TimeoutException:
         print("The scope element could not be found")
+        assert False
+    else:
         print(type(scope_decision))
         print(scope_decision)
         print(scope_decision.text)
-        assert False
 
     assert (
         scope in scope_decision.text

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -160,18 +160,16 @@ def step_impl_select_diagnosis_category(context):
 
 @step('I get an "{scope}" decision')
 def step_impl_scope_decision(context, scope):
-    summary_block_content = context.helperfunc.find_many_by_class(
-        "SummaryBlock-content"
-    )
 
-    summary_text = []
+    scope_xpath = "//main/div[2]/div/div/div[3]/div/div[2]/div/div/form/section/div[5]/p"
 
-    for element in summary_block_content:
-        summary_text.append(element.text)
+    scope_decision = context.helperfunc.find_by_xpath(scope_xpath)
 
+    print(type(scope_decision))
+    print(scope_decision)
     assert (
-        scope in summary_text
-    ), f"The diagnosis form contained the following text: {summary_text}, but did not find: {scope}"
+        scope in scope_decision.text
+    ), f"The diagnosis form contained the following text: {scope_decision.text}, but did not find: {scope}"
 
 
 @step('select the "{button_text}" button')

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -21,6 +21,7 @@ from common_steps import (
 )
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import StaleElementReferenceException
+from selenium.common.exceptions import TimeoutException
 from features.steps.common_steps import green_checkmark_appears_on_tab
 
 
@@ -166,7 +167,7 @@ def step_impl_scope_decision(context, scope):
 
     try:
         scope_decision = context.helperfunc.find_by_xpath(scope_xpath)
-    except TimeoutError:
+    except TimeoutException:
         print("The scope element could not be found")
         print(type(scope_decision))
         print(scope_decision)

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -160,8 +160,9 @@ def step_impl_select_diagnosis_category(context):
 
 @step('I get an "{scope}" decision')
 def step_impl_scope_decision(context, scope):
-
-    scope_xpath = "//main/div[2]/div/div/div[3]/div/div[2]/div/div/form/section/div[5]/p"
+    scope_xpath = (
+        "//main/div[2]/div/div/div[3]/div/div[2]/div/div/form/section/div[5]/p"
+    )
 
     scope_decision = context.helperfunc.find_by_xpath(scope_xpath)
 

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -164,11 +164,15 @@ def step_impl_scope_decision(context, scope):
         "//main/div[2]/div/div/div[3]/div/div[2]/div/div/form/section/div[5]/p"
     )
 
-    scope_decision = context.helperfunc.find_by_xpath(scope_xpath)
+    try:
+        scope_decision = context.helperfunc.find_by_xpath(scope_xpath)
+    except TimeoutError:
+        print("The scope element could not be found")
+        print(type(scope_decision))
+        print(scope_decision)
+        print(scope_decision.text)
+        assert False
 
-    print(type(scope_decision))
-    print(scope_decision)
-    print(scope_decision.text)
     assert (
         scope in scope_decision.text
     ), f"The diagnosis form contained the following text: {scope_decision.text}, but did not find: {scope}"

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -168,6 +168,7 @@ def step_impl_scope_decision(context, scope):
 
     print(type(scope_decision))
     print(scope_decision)
+    print(scope_decision.text)
     assert (
         scope in scope_decision.text
     ), f"The diagnosis form contained the following text: {scope_decision.text}, but did not find: {scope}"

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -162,7 +162,7 @@ def step_impl_select_diagnosis_category(context):
 @step('I get an "{scope}" decision')
 def step_impl_scope_decision(context, scope):
     scope_xpath = (
-        "//main/div[2]/div/div/div[3]/div/div[2]/div/div/form/section/div[5]/p"
+        f"//p[contains(text(), '{scope}')]"
     )
 
     try:


### PR DESCRIPTION
## What does this pull request do?

Cleans up the print statements, from the previous PR  [https://github.com/ministryofjustice/cla-end-to-end-tests/pull/124](https://github.com/ministryofjustice/cla-end-to-end-tests/pull/124), adding error messages to the assert statements to provide additional debugging context if the assertions fail.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"