### PR TITLE
LGA 2775 Immigration and Asylum Scope

### DIFF
--- a/behave/features/cla_frontend/frontend_immigration_asylum.feature
+++ b/behave/features/cla_frontend/frontend_immigration_asylum.feature
@@ -1,0 +1,38 @@
+@cla_frontend
+Feature: - Check additional question under the ‘immigration and asylum’ scope.
+
+  Background: Login
+    Given I am logged in as "CHS_GENERAL_USER"
+
+  @referred_by_provider_south_west
+  Scenario: Case has been referred by a provider in the south west of england.
+    Given I select to 'Create a case'
+    And I select ‘Create Scope Diagnosis'
+    When I select the "Immigration and asylum" option and click next
+    And I select the "any other matter - immigration" option and click next
+    And I select the "client was referred to CLA by a provider" option and click next
+    And I select the "Refer the client to the alternative list" option and click next
+    Then I get an "OUTOFSCOPE" decision
+
+  @referred_through_any_other_route
+  Scenario: Case has been referred through any other route.
+    Given I select to 'Create a case'
+    And I select ‘Create Scope Diagnosis'
+    When I select the "Immigration and asylum" option and click next
+    And I select the "any other matter - immigration" option and click next
+    And I select the "client came to CLA through any other route" option and click next
+    And I select the "Refer the client to FALA" option and click next
+    Then I get an "OUTOFSCOPE" decision
+
+  @referred_through_any_other_route
+  Scenario: Check South West England help text appears
+    Given I select to 'Create a case'
+    And I select ‘Create Scope Diagnosis'
+    When I select the "Immigration and asylum" option and click next
+    And I select the "any other matter - immigration" option and click next
+    And I click the help button on to the "any other matter - immigration" option
+    Then the help text for "any other matter - immigration" is:
+    """
+    South West of England consists of the counties of Cornwall (including the Isles of Scilly),
+     Dorset, Devon, Gloucestershire, Somerset and Wiltshire
+    """

--- a/behave/features/cla_frontend/frontend_immigration_asylum.feature
+++ b/behave/features/cla_frontend/frontend_immigration_asylum.feature
@@ -21,18 +21,17 @@ Feature: - Check additional question under the ‘immigration and asylum’ scop
     When I select the "Immigration and asylum" option and click next
     And I select the "any other matter - immigration" option and click next
     And I select the "client came to CLA through any other route" option and click next
-    And I select the "Refer the client to FALA" option and click next
+    And I select the "Refer the client to the Non CLA Disclaimer" option and click next
     Then I get an "OUTOFSCOPE" decision
 
-  @referred_through_any_other_route
+  @south_west_england_help_text
   Scenario: Check South West England help text appears
     Given I select to 'Create a case'
     And I select ‘Create Scope Diagnosis'
     When I select the "Immigration and asylum" option and click next
     And I select the "any other matter - immigration" option and click next
-    And I click the help button on to the "any other matter - immigration" option
-    Then the help text for "any other matter - immigration" is:
+    And I click the help button on the "client was referred to CLA by a provider" option
+    Then the help text for "client was referred to CLA by a provider" is
     """
-    South West of England consists of the counties of Cornwall (including the Isles of Scilly),
-     Dorset, Devon, Gloucestershire, Somerset and Wiltshire
+    South West of England consists of the counties of Cornwall (including the Isles of Scilly), Dorset, Devon, Gloucestershire, Somerset and Wiltshire
     """

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -362,3 +362,42 @@ def assert_element_does_not_appear(context, name):
     )
     question = name.replace("_", " ")
     assert len(radio_button_element) == 0, f"Expected {question} question to be hidden"
+
+
+def get_node_from_option_name(name: str) -> str:
+    """
+    Takes in a name and returns the corresponding angular node ID.
+    Param: name - str
+    Return: node_id - str or None, if not found
+    """
+    name = name.lower()
+    option_node_map = {
+        "family": "n97",
+        "special guardianship order": "n410",
+        "parent": "n411",
+        "other person": "n412",
+        "immigration and asylum": "n186",
+        "any other matter - immigration": "n187",  # Incase "any other matter" appears twice, specify the category.
+        "client was referred to CLA by a provider": "NODE NUMBER PLEASE",
+        "client came to CLA through any other route": "NODE NUMBER PLEASE",
+        "refer the client to the alternative list": "NODE NUMBER PLEASE",
+        "refer the client to fala": "NODE NUMBER PLEASE",
+    }
+    if name in option_node_map.keys():
+        return option_node_map[name]
+    return None
+
+
+@step("I click the help button on to the {option} option")
+def step_impl_click_help_button(context, option: str):
+    node = get_node_from_option_name(option)
+
+    if node is None:
+        assert False, f"Node for {option} could not be found"
+
+    # Gets the element of the associated radio button, finds it's parent's parent
+    # and drills down to it's associated help button.
+    help_button_element = context.helperfunc.find_by_xpath(
+        f"//input[@value='{node}']/../../details/summary"
+    )
+    help_button_element.click()

--- a/behave/features/steps/common_steps.py
+++ b/behave/features/steps/common_steps.py
@@ -378,17 +378,17 @@ def get_node_from_option_name(name: str) -> str:
         "other person": "n412",
         "immigration and asylum": "n186",
         "any other matter - immigration": "n187",  # Incase "any other matter" appears twice, specify the category.
-        "client was referred to CLA by a provider": "NODE NUMBER PLEASE",
-        "client came to CLA through any other route": "NODE NUMBER PLEASE",
-        "refer the client to the alternative list": "NODE NUMBER PLEASE",
-        "refer the client to fala": "NODE NUMBER PLEASE",
+        "client was referred to cla by a provider": "n190",
+        "client came to cla through any other route": "n188",
+        "refer the client to the alternative list": "n351",
+        "refer the client to the non cla disclaimer": "n302",
     }
     if name in option_node_map.keys():
         return option_node_map[name]
     return None
 
 
-@step("I click the help button on to the {option} option")
+@step('I click the help button on the "{option}" option')
 def step_impl_click_help_button(context, option: str):
     node = get_node_from_option_name(option)
 

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -591,8 +591,8 @@ def step_impl_select_radio_button_option_by_value(context, option):
     context.helperfunc.click_button(By.NAME, "diagnosis-next")
 
 
-@step('the help text for "{option}" is: "{help_text}')
-def step_impl_check_help_text_exists(context, option, help_text):
+@step('the help text for "{option}" is')
+def step_impl_check_help_text_exists(context, option):
     node = get_node_from_option_name(option)
 
     if node is None:
@@ -603,4 +603,6 @@ def step_impl_check_help_text_exists(context, option, help_text):
     help_text_container = context.helperfunc.find_by_xpath(
         f"//input[@value='{node}']/../../details/div"
     )
-    assert help_text_container.text == help_text
+
+    print(help_text_container.text)
+    assert help_text_container.text == context.text

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -18,6 +18,7 @@ from common_steps import (
     switch_to_new_tab,
     select_value_from_list,
     search_and_select_case,
+    get_node_from_option_name,
 )
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import StaleElementReferenceException
@@ -581,16 +582,25 @@ def step_impl_assign_f2f(context):
 
 @step('I select the "{option}" option and click next')
 def step_impl_select_radio_button_option_by_value(context, option):
-    value = ""
-    if option == "Family":
-        value = "n97"
-    if option == "Special Guardianship Order":
-        value = "n410"
-    if option == "parent":
-        value = "n411"
-    if option == "other person":
-        value = "n412"
+
+    value = get_node_from_option_name(option)
+
     context.helperfunc.click_button(
         By.CSS_SELECTOR, f"input[type='radio'][value='{value}']"
     )
     context.helperfunc.click_button(By.NAME, "diagnosis-next")
+
+
+@step('the help text for "{option}" is: "{help_text}')
+def step_impl_check_help_text_exists(context, option, help_text):
+    node = get_node_from_option_name(option)
+
+    if node is None:
+        assert False, f"Node for {option} could not be found"
+
+        # Gets the element of the associated radio button, finds it's parent's parent
+        # and drills down to it's associated help button.
+    help_text_container = context.helperfunc.find_by_xpath(
+        f"//input[@value='{node}']/../../details/div"
+    )
+    assert help_text_container.text == help_text

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -604,5 +604,4 @@ def step_impl_check_help_text_exists(context, option):
         f"//input[@value='{node}']/../../details/div"
     )
 
-    print(help_text_container.text)
     assert help_text_container.text == context.text

--- a/behave/features/steps/frontend_assignment.py
+++ b/behave/features/steps/frontend_assignment.py
@@ -598,8 +598,8 @@ def step_impl_check_help_text_exists(context, option):
     if node is None:
         assert False, f"Node for {option} could not be found"
 
-        # Gets the element of the associated radio button, finds it's parent's parent
-        # and drills down to it's associated help button.
+    # Gets the element of the associated radio button, finds it's parent's parent
+    # and drills down to it's associated help button.
     help_text_container = context.helperfunc.find_by_xpath(
         f"//input[@value='{node}']/../../details/div"
     )


### PR DESCRIPTION
## What does this pull request do?

- Adds end-to-end tests for the work done in [LGA 2775](https://github.com/ministryofjustice/cla_backend/pull/1013).
- These test both new flows and assert that the added help text works as expected.

## Any other changes that would benefit highlighting?

Adds a new helper function named `get_node_from_option_name` which takes in a name string and returns the angular node ID for the option. This is a common requirement when writing scope end-to-end tests.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"