### PR TITLE
El 1434 fala url changed

### DIFF
--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -71,7 +71,7 @@ def step_impl_search_clicked(context):
 @step('I am taken to the page corresponding to "{location}" result')
 def step_impl_result_page_with_location_only(context, location):
     expected_url = (
-        f"{CLA_FALA_URL}/?postcode={location.replace(' ', '+')}&name=&search="
+        f"{CLA_FALA_URL}/search?postcode={location.replace(' ', '+')}&name=&search="
     )
     expected_title = FALA_HEADER
 

--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -95,7 +95,7 @@ def step_impl_apply_filter_on_homepage(context):
 )
 def step_impl_apply_filter_on_result_page(context, location, filter_label):
     location_format = location.replace(" ", "+")
-    expected_url = f"{CLA_FALA_URL}/?postcode={location_format}&name=&categories={filter_label}&filter="
+    expected_url = f"{CLA_FALA_URL}/search?postcode={location_format}&name=&categories={filter_label}&filter="
     expected_title = FALA_HEADER
 
     assert_result_page(context, expected_url, expected_title)
@@ -119,7 +119,7 @@ def step_impl_result_page_with_location_organisation_provided(
     organisation_format = organisation.replace(" ", "+")
     location_format = location.replace(" ", "+")
     expected_url = (
-        f"{CLA_FALA_URL}/?postcode={location_format}&name={organisation_format}&search="
+        f"{CLA_FALA_URL}/search?postcode={location_format}&name={organisation_format}&search="
     )
     expected_title = FALA_HEADER
 


### PR DESCRIPTION
## What does this pull request do?

Change the FALA search URL from / to /search

## Any other changes that would benefit highlighting?

This is a result of the FALA re-work, where the new code used /search - the old code also uses /search but is sent to the old behaviour if the FEATURE_FLAG_FALA_NO_MAP is set on. The tests cannot pass w/o the corresponding change to FALA being merged, but FALA needs this branch to exist so that its tests pass

## Checklist

- [X] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"