### PR TITLE
click on label for checkboxes rather than on the checkbox itself

### DIFF
--- a/behave/features/steps/fala_end_to_end_tests.py
+++ b/behave/features/steps/fala_end_to_end_tests.py
@@ -80,9 +80,11 @@ def step_impl_result_page_with_location_only(context, location):
 
 @step('I browse through the filter categories and select "{filter_label}"')
 def step_impl_checkbox_filter_clicked(context, filter_label):
-    context.helperfunc.click_button(
-        By.CSS_SELECTOR, f"input[type='checkbox'][value='{filter_label}']"
-    )
+    checkbox_id = context.helperfunc.find_by_css_selector_without_wait(
+        f"input[type='checkbox'][value='{filter_label}']"
+    ).get_attribute("id")
+    # click the label for the checkbox rather than the checkbox itself
+    context.helperfunc.find_by_css_selector(f"label[for='{checkbox_id}']").click()
 
 
 @step('I select the "Apply filter" button')

--- a/behave/helper/helper_base.py
+++ b/behave/helper/helper_base.py
@@ -77,6 +77,9 @@ class HelperFunc(object):
             EC.visibility_of_element_located((By.CSS_SELECTOR, css))
         )
 
+    def find_by_css_selector_without_wait(self, css):
+        return self._driver.find_element(By.CSS_SELECTOR, css)
+
     def find_by_name(self, name):
         return self._driver_wait.until(
             EC.visibility_of_element_located((By.NAME, name))


### PR DESCRIPTION
## What does this pull request do?

When CSS is applied to a test environment, the naive tests no longer pass as govuk checkboxes are not visible (they are overlaid with other items to make the content more visually appealing). This  change fixes the behave tests to click on the label rather than the checkbox, as that is visible

## Any other changes that would benefit highlighting?

This was found by enabling CSS in FALA behave tests

## Checklist

- [ ] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"