### PR TITLE
LGA-3903 - Make cla_frontend use legacy auth instead of the new entra id auth

### DIFF
--- a/behave/docker-compose.yml
+++ b/behave/docker-compose.yml
@@ -100,6 +100,7 @@ services:
       SESSION_COOKIE_SECURE: "False"
       SESSION_COOKIE_SAMESITE: "None"
       SESSION_COOKIE_HTTPONLY: "False"
+      USE_LEGACY_AUTH: "True"
 
   clafrontendooh:
     <<: *clafrontend


### PR DESCRIPTION
## What does this pull request do?

Make cla_frontend use legacy auth instead of the new entra id auth.

## Any other changes that would benefit highlighting?

Intentionally left blank.

## Checklist

- [x] Provided JIRA ticket number in the title, e.g. "LGA-152: Sample title"